### PR TITLE
[BE] 네이버 소셜 로그인 기능 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -29,7 +29,10 @@ lerna-debug.log*
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# ENV FIles
+.env

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,9 +11,13 @@
       "dependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.0",
+        "dotenv": "^16.3.1",
         "mysql2": "^3.6.3",
+        "passport": "^0.6.0",
+        "passport-naver-v2": "^2.0.8",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17"
@@ -1659,6 +1663,15 @@
         }
       }
     },
+    "node_modules/@nestjs/passport": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.2.tgz",
+      "integrity": "sha512-od31vfB2z3y05IDB5dWSbCGE2+pAf2k2WCBinNuTTOxN0O0+wtO1L3kawj/aCW3YR9uxsTOVbTDwtwgpNNsnjQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "passport": "^0.4.0 || ^0.5.0 || ^0.6.0"
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.2.8.tgz",
@@ -2846,6 +2859,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -6732,6 +6753,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6960,6 +6986,58 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-naver-v2": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz",
+      "integrity": "sha512-CA0u+aA4K4Zf5e3dSd47agOS69ULOdBGei7CZY2BN1cEbLnhnc6OalFPvnXLuEKT8I4IuGwvh3EBZCST2FoI+A==",
+      "dependencies": {
+        "passport-oauth2": "^1.5.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
+      "integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7031,6 +7109,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -8849,6 +8932,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,9 +22,13 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "dotenv": "^16.3.1",
     "mysql2": "^3.6.3",
+    "passport": "^0.6.0",
+    "passport-naver-v2": "^2.0.8",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,9 @@
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
-  imports: [],
-  controllers: [AppController],
-  providers: [AppService],
+  imports: [AuthModule],
+  controllers: [],
+  providers: [],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { typeORMConfig } from './configs/typeorm.config';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, TypeOrmModule.forRoot(typeORMConfig)],
   controllers: [],
   providers: [],
 })

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import { NaverAuthGuard } from './guards/naverAuth.guard';
+
+@Controller('auth')
+export class AuthController {
+  constructor() {}
+
+  @Get('naver/login')
+  @UseGuards(NaverAuthGuard)
+  async naverLogin(): Promise<void> {}
+
+  @Get('naver/callback')
+  @UseGuards(NaverAuthGuard)
+  async naverLoginCallback(@Req() req, @Res() res): Promise<void> {
+    return res.json({
+      user: req.user,
+    });
+  }
+}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get, Res, UseGuards } from '@nestjs/common';
 import { NaverAuthGuard } from './guards/naverAuth.guard';
 import { User } from './utils/user.decorator';
+import { CreateUserDto } from './dto/createUserDto';
+import { AuthService } from './auth.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor() {}
+  constructor(private readonly authService: AuthService) {}
 
   @Get('naver/login')
   @UseGuards(NaverAuthGuard)
@@ -12,7 +14,8 @@ export class AuthController {
 
   @Get('naver/callback')
   @UseGuards(NaverAuthGuard)
-  async naverLoginCallback(@User() user, @Res() res): Promise<void> {
+  async naverLoginCallback(@User() user: CreateUserDto, @Res() res): Promise<void> {
+    this.authService.login(user);
     return res.json({
       user,
     });

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import { NaverAuthGuard } from './guards/naverAuth.guard';
 import { User } from './utils/user.decorator';
 import { CreateUserDto } from './dto/createUserDto';
 import { AuthService } from './auth.service';
+import { CreateUserResponseDto } from './dto/createUserResponseDto';
 
 @Controller('auth')
 export class AuthController {
@@ -14,7 +15,9 @@ export class AuthController {
 
   @Get('naver/callback')
   @UseGuards(NaverAuthGuard)
-  async naverLoginCallback(@User() user: CreateUserDto): Promise<number> {
-    return await this.authService.login(user);
+  async naverLoginCallback(@User() user: CreateUserDto): Promise<CreateUserResponseDto> {
+    const userId = await this.authService.login(user);
+
+    return { userId };
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -15,6 +15,6 @@ export class AuthController {
   @Get('naver/callback')
   @UseGuards(NaverAuthGuard)
   async naverLoginCallback(@User() user: CreateUserDto): Promise<number> {
-    return this.authService.login(user);
+    return await this.authService.login(user);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { NaverAuthGuard } from './guards/naverAuth.guard';
 import { User } from './utils/user.decorator';
 import { CreateUserDto } from './dto/createUserDto';
@@ -10,14 +10,11 @@ export class AuthController {
 
   @Get('naver/login')
   @UseGuards(NaverAuthGuard)
-  async naverLogin(): Promise<void> {}
+  naverLogin(): void {}
 
   @Get('naver/callback')
   @UseGuards(NaverAuthGuard)
-  async naverLoginCallback(@User() user: CreateUserDto, @Res() res): Promise<void> {
-    this.authService.login(user);
-    return res.json({
-      user,
-    });
+  async naverLoginCallback(@User() user: CreateUserDto): Promise<number> {
+    return this.authService.login(user);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Res, UseGuards } from '@nestjs/common';
 import { NaverAuthGuard } from './guards/naverAuth.guard';
+import { User } from './utils/user.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -11,9 +12,9 @@ export class AuthController {
 
   @Get('naver/callback')
   @UseGuards(NaverAuthGuard)
-  async naverLoginCallback(@Req() req, @Res() res): Promise<void> {
+  async naverLoginCallback(@User() user, @Res() res): Promise<void> {
     return res.json({
-      user: req.user,
+      user,
     });
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { NaverStrategy } from './strategy/naverAuth.strategy';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService, NaverStrategy],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { NaverStrategy } from './strategy/naverAuth.strategy';
+import { UserRepository } from './auth.repository';
 
 @Module({
   controllers: [AuthController],
-  providers: [AuthService, NaverStrategy],
+  providers: [AuthService, UserRepository, NaverStrategy],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.repository.ts
+++ b/backend/src/auth/auth.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { User } from './entity/user.entity';
+import { CreateUserDto } from './dto/createUserDto';
+
+@Injectable()
+export class UserRepository extends Repository<User> {
+  constructor(private dataSource: DataSource) {
+    super(User, dataSource.createEntityManager());
+  }
+
+  async findBySocialIdAndSocialType(socialId: string, socialType: string): Promise<User> {
+    return await this.createQueryBuilder('user')
+      .where('user.socialId = :socialId', { socialId })
+      .andWhere('user.socialType = :socialType', { socialType })
+      .getOne();
+  }
+
+  async createUser(createUserDto: CreateUserDto): Promise<User> {
+    const { id, email, nickname, socialType } = createUserDto;
+
+    return this.save({ socialId: id, email, nickname, socialType });
+  }
+}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthService {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,15 +6,16 @@ import { UserRepository } from './auth.repository';
 export class AuthService {
   constructor(private readonly userRepository: UserRepository) {}
 
-  async login(user: CreateUserDto) {
+  async login(user: CreateUserDto): number {
     const duplicateUser = await this.userRepository.findBySocialIdAndSocialType(
       user.id,
       user.socialType,
     );
     if (!duplicateUser) {
-      await this.userRepository.createUser(user);
+      return (await this.userRepository.createUser(user)).id;
     }
 
     //TODO: JWT 토큰 반환
+    return -1;
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,7 +6,7 @@ import { UserRepository } from './auth.repository';
 export class AuthService {
   constructor(private readonly userRepository: UserRepository) {}
 
-  async login(user: CreateUserDto): number {
+  async login(user: CreateUserDto): Promise<number> {
     const duplicateUser = await this.userRepository.findBySocialIdAndSocialType(
       user.id,
       user.socialType,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import { CreateUserDto } from './dto/createUserDto';
+import { UserRepository } from './auth.repository';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async login(user: CreateUserDto) {
+    const duplicateUser = await this.userRepository.findBySocialIdAndSocialType(
+      user.id,
+      user.socialType,
+    );
+    if (!duplicateUser) {
+      await this.userRepository.createUser(user);
+    }
+
+    //TODO: JWT 토큰 반환
+  }
+}

--- a/backend/src/auth/dto/createUserDto.ts
+++ b/backend/src/auth/dto/createUserDto.ts
@@ -1,0 +1,6 @@
+export class CreateUserDto {
+  id: string;
+  email: string;
+  nickname: string;
+  socialType: string;
+}

--- a/backend/src/auth/dto/createUserDto.ts
+++ b/backend/src/auth/dto/createUserDto.ts
@@ -1,6 +1,8 @@
+import { SocialType } from '../entity/socialType';
+
 export class CreateUserDto {
   id: string;
   email: string;
   nickname: string;
-  socialType: string;
+  socialType: SocialType;
 }

--- a/backend/src/auth/dto/createUserResponseDto.ts
+++ b/backend/src/auth/dto/createUserResponseDto.ts
@@ -1,0 +1,3 @@
+export class CreateUserResponseDto {
+  userId: number;
+}

--- a/backend/src/auth/entity/socialType.ts
+++ b/backend/src/auth/entity/socialType.ts
@@ -1,0 +1,4 @@
+export enum SocialType {
+  NAVER = 'naver',
+  GOOGLE = 'google',
+}

--- a/backend/src/auth/entity/user.entity.ts
+++ b/backend/src/auth/entity/user.entity.ts
@@ -1,0 +1,36 @@
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class User extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  email: string;
+
+  @Column()
+  nickname: string;
+
+  @Column()
+  socialId: string;
+
+  @Column()
+  socialType: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
+}

--- a/backend/src/auth/entity/user.entity.ts
+++ b/backend/src/auth/entity/user.entity.ts
@@ -7,6 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { SocialType } from './socialType';
 
 @Entity()
 export class User extends BaseEntity {
@@ -23,7 +24,7 @@ export class User extends BaseEntity {
   socialId: string;
 
   @Column()
-  socialType: string;
+  socialType: SocialType;
 
   @Column()
   profileImage: string;

--- a/backend/src/auth/entity/user.entity.ts
+++ b/backend/src/auth/entity/user.entity.ts
@@ -25,6 +25,9 @@ export class User extends BaseEntity {
   @Column()
   socialType: string;
 
+  @Column()
+  profileImage: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/auth/guards/naverAuth.guard.ts
+++ b/backend/src/auth/guards/naverAuth.guard.ts
@@ -1,0 +1,5 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NaverAuthGuard extends AuthGuard('naver') {}

--- a/backend/src/auth/strategy/naverAuth.strategy.ts
+++ b/backend/src/auth/strategy/naverAuth.strategy.ts
@@ -2,8 +2,7 @@ import { Profile, Strategy } from 'passport-naver-v2';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { SocialType } from '../entity/socialType';
-
-require('dotenv').config();
+import 'dotenv/config';
 
 type VerifyCallback = (error: Error, user?: any, info?: any) => void;
 

--- a/backend/src/auth/strategy/naverAuth.strategy.ts
+++ b/backend/src/auth/strategy/naverAuth.strategy.ts
@@ -4,6 +4,8 @@ import { Injectable } from '@nestjs/common';
 
 require('dotenv').config();
 
+type VerifyCallback = (error: Error, user?: any, info?: any) => void;
+
 @Injectable()
 export class NaverStrategy extends PassportStrategy(Strategy) {
   constructor() {
@@ -14,12 +16,12 @@ export class NaverStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(
+  validate(
     accessToken: string,
     refreshToken: string,
     profile: Profile,
-    done: any,
-  ): Promise<any> {
+    done: VerifyCallback,
+  ): void {
     const { id, email, nickname } = profile;
     const user = {
       id,

--- a/backend/src/auth/strategy/naverAuth.strategy.ts
+++ b/backend/src/auth/strategy/naverAuth.strategy.ts
@@ -25,6 +25,7 @@ export class NaverStrategy extends PassportStrategy(Strategy) {
       id,
       email,
       nickname,
+      socialType: 'naver',
     };
 
     return done(null, user);

--- a/backend/src/auth/strategy/naverAuth.strategy.ts
+++ b/backend/src/auth/strategy/naverAuth.strategy.ts
@@ -1,0 +1,32 @@
+import { Profile, Strategy } from 'passport-naver-v2';
+import { PassportStrategy } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+
+require('dotenv').config();
+
+@Injectable()
+export class NaverStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      clientID: process.env.NAVER_CLIENT_ID,
+      clientSecret: process.env.NAVER_CLIENT_SECRET,
+      callbackURL: process.env.NAVER_CALLBACK_URL,
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: any,
+  ): Promise<any> {
+    const { id, email, nickname } = profile;
+    const user = {
+      id,
+      email,
+      nickname,
+    };
+
+    return done(null, user);
+  }
+}

--- a/backend/src/auth/strategy/naverAuth.strategy.ts
+++ b/backend/src/auth/strategy/naverAuth.strategy.ts
@@ -1,6 +1,7 @@
 import { Profile, Strategy } from 'passport-naver-v2';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
+import { SocialType } from '../entity/socialType';
 
 require('dotenv').config();
 
@@ -27,7 +28,7 @@ export class NaverStrategy extends PassportStrategy(Strategy) {
       id,
       email,
       nickname,
-      socialType: 'naver',
+      socialType: SocialType.NAVER,
     };
 
     return done(null, user);

--- a/backend/src/auth/utils/user.decorator.ts
+++ b/backend/src/auth/utils/user.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const User = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest();
+  return request.user;
+});

--- a/backend/src/auth/utils/user.decorator.ts
+++ b/backend/src/auth/utils/user.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
-export const User = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
-  const request = ctx.switchToHttp().getRequest();
+export const User = createParamDecorator((data: unknown, executionContext: ExecutionContext) => {
+  const request = executionContext.switchToHttp().getRequest();
   return request.user;
 });

--- a/backend/src/configs/typeorm.config.ts
+++ b/backend/src/configs/typeorm.config.ts
@@ -1,0 +1,14 @@
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+
+require('dotenv').config();
+
+export const typeORMConfig: TypeOrmModuleOptions = {
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME,
+  entities: [__dirname + '/../**/*.entity.{js,ts}'],
+  synchronize: true,
+};

--- a/backend/src/configs/typeorm.config.ts
+++ b/backend/src/configs/typeorm.config.ts
@@ -1,6 +1,5 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
-
-require('dotenv').config();
+import 'dotenv/config';
 
 export const typeORMConfig: TypeOrmModuleOptions = {
   type: 'mysql',


### PR DESCRIPTION
### 이슈번호 

#8 

### 완료한 기능 명세

- [x] 네이버 소셜 로그인 구현
- [x] 사용자 값 DB 저장(typeORM 적용)

### 기능 설명

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/4ce7f4b7-8283-4553-9451-736d668a00e4)

- naver api와 연동해 사용자 정보를 가져오도록 구현했습니다.

```ts
export const User = createParamDecorator((data: unknown, executionContext: ExecutionContext) => {
  const request = executionContext.switchToHttp().getRequest();
  return request.user;
});
```
- oauth callback 이외에도 jwt 파싱에서도 사용될 수 있도록 `@User` 데코레이터를 구현했습니다.
- guard를 거쳐 `req`객체에 저장된 user 정보를 바로 반환해주는 기능을 수행합니다.
  - `req.user` -> `user`