### PR TITLE
[BE] PM2를 이용한 무중단 배포 적용

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -25,4 +25,4 @@ jobs:
           yarn install
           yarn frontend build
           yarn backend build
-          yarn backend run start:prod
+          pm2 reload main


### PR DESCRIPTION
## 이슈 번호

#7 

## 완료한 기능 명세

- 서비스 서버에 PM2 설치
  ```
  yarn global add pm2
  ```

- entry point인 `/backend/dist/main.js` 를 데몬화하여 모니터링
  ```
  pm2 start main.js
  ```
  ![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/457bc3c1-aad6-4279-a87d-878cf7fb0d7a)

- develop-cd script 수정
  기존에 프로그램을 중단하지 않고 그냥 실행시키는 `yarn backend run start:prod`에서
  프로세스를 중단 후 다시 실행시키는 `pm2 reload main`으로 script 변경

  ![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/792039d2-5d41-4a29-9aa9-77af5080dd90)

  이후 error 없이 잘 동작하는 것을 볼 수 있다.

