### PR TITLE
[BE] 일기 엔티티 생성

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,9 +3,10 @@ import { AuthModule } from './auth/auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeORMConfig } from './configs/typeorm.config';
 import { LoggerMiddleware } from './middleware/logger.middleware';
+import { DiaryModule } from './diary/diary.module';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forRoot(typeORMConfig)],
+  imports: [AuthModule, TypeOrmModule.forRoot(typeORMConfig), DiaryModule],
   controllers: [],
   providers: [],
 })

--- a/backend/src/diary/diary.module.ts
+++ b/backend/src/diary/diary.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class DiaryModule {}

--- a/backend/src/diary/entity/diary.entity.ts
+++ b/backend/src/diary/entity/diary.entity.ts
@@ -1,0 +1,59 @@
+import { User } from 'src/auth/entity/user.entity';
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { DiaryStatus } from './diaryStatus';
+import { Tag } from './tag.entity';
+
+@Entity()
+export class Diary extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  content: string;
+
+  @Column({ nullable: false })
+  thumbnail?: string;
+
+  @Column()
+  emotion: string;
+
+  @Column()
+  mood: number;
+
+  @Column()
+  status: DiaryStatus;
+
+  @ManyToOne(() => User)
+  author: User;
+
+  @ManyToMany(() => Tag, { cascade: true })
+  @JoinTable({
+    name: 'diary_tag',
+    joinColumn: { name: 'diary_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'tag_id', referencedColumnName: 'id' },
+  })
+  tags: Tag[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
+}

--- a/backend/src/diary/entity/diaryStatus.ts
+++ b/backend/src/diary/entity/diaryStatus.ts
@@ -1,0 +1,4 @@
+export enum DiaryStatus {
+  PRIVATE = 'private',
+  PUBLIC = 'public',
+}

--- a/backend/src/diary/entity/tag.entity.ts
+++ b/backend/src/diary/entity/tag.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { Diary } from './diary.entity';
 
-@Entity('permissions')
+@Entity()
 export class Tag {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/diary/entity/tag.entity.ts
+++ b/backend/src/diary/entity/tag.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Diary } from './diary.entity';
+
+@Entity('permissions')
+export class Tag {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @ManyToMany(() => Diary, { cascade: true })
+  diaries: Diary[];
+}


### PR DESCRIPTION
## 이슈 번호

#11 

## 완료한 기능 명세

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/f700d5a8-30ae-4bf8-b1cf-559a908c6c27)

- 일기 CRUD API 구현 이전에 ERD와 동일하게 엔티티를 작성했습니다.
- 리액션 같은 경우 일기 CRUD 단계에서는 불필요해보여 작성하지 않았습니다. 
