### PR TITLE
[FE] 홈 프로필 섹션 UI 구현

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>단디</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Common/Button.tsx
+++ b/frontend/src/components/Common/Button.tsx
@@ -5,13 +5,14 @@ interface ButtonProps {
   height: number;
   text: string;
   fontColor: string;
+  fontSize?: string;
   backgroundColor: string;
 }
 
-const Button = ({ width, height, text, fontColor, backgroundColor }: ButtonProps) => {
+const Button = ({ width, height, text, fontColor, fontSize, backgroundColor }: ButtonProps) => {
   return (
     <button
-      className={`w-[${width}rem] h-[${height}rem] text-${fontColor} font-bold bg-[${backgroundColor}] rounded-lg`}
+      className={`w-[${width}rem] h-[${height}rem] text-${fontColor} font-bold text-${fontSize} bg-[${backgroundColor}] rounded-lg`}
     >
       {text}
     </button>

--- a/frontend/src/components/Home/Profile.tsx
+++ b/frontend/src/components/Home/Profile.tsx
@@ -15,30 +15,44 @@ export const Profile = ({
 }: ProfileProps) => {
   const greetMessages = ['좋은 하루예요!', '안녕하세요!', '반가워요!'];
   const getRandomIndex = Math.floor(Math.random() * greetMessages.length);
-  const friendCount = 20;
 
   return (
     <section className="flex flex-col items-center justify-center gap-14">
       <div className="flex flex-row items-center justify-center">
         <img
           className="h-52 w-52 rounded-full object-cover"
-          src="https://i.namu.wiki/i/VMIHkLm6DcUT4d9-vN4yFw7Yfitr8luT_U2YwJsugGodCQ01ooGH_kHX0D6sJ3HDS1YHfvy9B81al8rKCxqKYw.webp"
+          src={profileImage}
           alt="나의 프로필 사진"
         />
         <div className="ml-10">
-          <p className="mb-8 text-3xl font-black">
+          <p className="mb-8 text-3xl font-bold">
             {nickname}님, {greetMessages[getRandomIndex]}
           </p>
           <div className="border-brown grid w-max grid-flow-col rounded-2xl border-2 border-solid p-5 text-center text-lg font-bold">
-            <p>친구 {totalFriends}명</p>
+            <p className="cursor-pointer">친구 {totalFriends}명</p>
             <div className="border-brown w mx-5 border-l-2 border-solid" />
-            <p>친구 관리</p>
+            <p className="cursor-pointer">친구 관리</p>
             <div className="border-brown w mx-5 border-l-2 border-solid" />
-            <p>내 정보 수정</p>
+            <p className="cursor-pointer">내 정보 수정</p>
           </div>
         </div>
       </div>
       {isExistedTodayDiary ? (
+        <>
+          <div className="text-center text-2xl font-bold">
+            <p>오늘 일기를 작성하셨네요!</p>
+            <p>작성하신 일기를 보여드릴게요.</p>
+          </div>
+          <Button
+            width={36}
+            height={4.6875}
+            text={'오늘 하루 보러 가기'}
+            fontColor="default"
+            fontSize="xl"
+            backgroundColor="mint"
+          />
+        </>
+      ) : (
         <>
           <div className="text-center text-2xl font-bold">
             <p>아직 오늘 일기를 작성하지 않으셨네요!</p>
@@ -49,20 +63,7 @@ export const Profile = ({
             height={4.6875}
             text={'오늘 하루 기록하기'}
             fontColor="default"
-            backgroundColor="mint"
-          />
-        </>
-      ) : (
-        <>
-          <div className="text-center text-2xl font-bold">
-            <p>오늘 일기를 작성하셨네요!</p>
-            <p>작성하신 일기를 보여드릴게요</p>
-          </div>
-          <Button
-            width={36}
-            height={4.6875}
-            text={'오늘 하루 보러 가기'}
-            fontColor="default"
+            fontSize="2xl"
             backgroundColor="mint"
           />
         </>

--- a/frontend/src/components/Home/Profile.tsx
+++ b/frontend/src/components/Home/Profile.tsx
@@ -1,0 +1,72 @@
+import Button from '../Common/Button';
+
+interface ProfileProps {
+  nickname: string;
+  profileImage: string;
+  totalFriends: number;
+  isExistedTodayDiary: boolean;
+}
+
+export const Profile = ({
+  nickname,
+  profileImage,
+  totalFriends,
+  isExistedTodayDiary,
+}: ProfileProps) => {
+  const greetMessages = ['좋은 하루예요!', '안녕하세요!', '반가워요!'];
+  const getRandomIndex = Math.floor(Math.random() * greetMessages.length);
+  const friendCount = 20;
+
+  return (
+    <section className="flex flex-col items-center justify-center gap-14">
+      <div className="flex flex-row items-center justify-center">
+        <img
+          className="h-52 w-52 rounded-full object-cover"
+          src="https://i.namu.wiki/i/VMIHkLm6DcUT4d9-vN4yFw7Yfitr8luT_U2YwJsugGodCQ01ooGH_kHX0D6sJ3HDS1YHfvy9B81al8rKCxqKYw.webp"
+          alt="나의 프로필 사진"
+        />
+        <div className="ml-10">
+          <p className="mb-8 text-3xl font-black">
+            {nickname}님, {greetMessages[getRandomIndex]}
+          </p>
+          <div className="border-brown grid w-max grid-flow-col rounded-2xl border-2 border-solid p-5 text-center text-lg font-bold">
+            <p>친구 {totalFriends}명</p>
+            <div className="border-brown w mx-5 border-l-2 border-solid" />
+            <p>친구 관리</p>
+            <div className="border-brown w mx-5 border-l-2 border-solid" />
+            <p>내 정보 수정</p>
+          </div>
+        </div>
+      </div>
+      {isExistedTodayDiary ? (
+        <>
+          <div className="text-center text-2xl font-bold">
+            <p>아직 오늘 일기를 작성하지 않으셨네요!</p>
+            <p>일기를 작성해볼까요?</p>
+          </div>
+          <Button
+            width={36}
+            height={4.6875}
+            text={'오늘 하루 기록하기'}
+            fontColor="default"
+            backgroundColor="mint"
+          />
+        </>
+      ) : (
+        <>
+          <div className="text-center text-2xl font-bold">
+            <p>오늘 일기를 작성하셨네요!</p>
+            <p>작성하신 일기를 보여드릴게요</p>
+          </div>
+          <Button
+            width={36}
+            height={4.6875}
+            text={'오늘 하루 보러 가기'}
+            fontColor="default"
+            backgroundColor="mint"
+          />
+        </>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,10 +1,17 @@
 import DiaryList from '../components/Common/DiaryList';
 import NavBar from '../components/Common/NavBar';
+import { Profile } from '../components/Home/Profile';
 
 const Home = () => {
   return (
-    <main className="flex flex-col items-center">
+    <main className="mb-28 flex flex-col items-center">
       <NavBar />
+      <Profile
+        nickname="윤주"
+        isExistedTodayDiary={false}
+        totalFriends={10}
+        profileImage="https://i.namu.wiki/i/VMIHkLm6DcUT4d9-vN4yFw7Yfitr8luT_U2YwJsugGodCQ01ooGH_kHX0D6sJ3HDS1YHfvy9B81al8rKCxqKYw.webp"
+      />
       <DiaryList />
     </main>
   );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,10 +3,10 @@ import NavBar from '../components/Common/NavBar';
 
 const Home = () => {
   return (
-    <div>
+    <main className="flex flex-col items-center">
       <NavBar />
       <DiaryList />
-    </div>
+    </main>
   );
 };
 


### PR DESCRIPTION
## 이슈 번호
#39

## 완료한 기능 명세
<img width="751" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/0fe051c1-191d-4303-8857-8eb31fe86d87">

- 홈 페이지의 프로필 섹션 UI 구현
- 홈 페이지 flex 레이아웃 정렬 수정
- 버튼 컴포넌트의 폰트 크기 조정 prop 추가