### PR TITLE
[BE] 일기 조회 API 구현

### DIFF
--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -39,7 +39,7 @@ export class DiariesController {
       thumbnail: diary.thumbnail,
       emotion: diary.emotion,
       mood: diary.mood,
-      keywords: diary.tags?.map((t) => t.name),
+      tags: diary.tags?.map((t) => t.name),
       reactionCount: null,
     };
   }

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -1,6 +1,16 @@
-import { Body, Controller, Post, UseGuards, UsePipes, ValidationPipe } from '@nestjs/common';
-import { ApiBody, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { CreateDiaryDto } from './dto/diary.dto';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CreateDiaryDto, GetDiaryResponseDto } from './dto/diary.dto';
 import { DiariesService } from './diaries.service';
 import { User as UserEntity } from 'src/users/entity/user.entity';
 import { User } from 'src/users/utils/user.decorator';
@@ -10,6 +20,29 @@ import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
 @Controller('diaries')
 export class DiariesController {
   constructor(private readonly diariesService: DiariesService) {}
+
+  @Get('/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ description: '일기 조회 API' })
+  @ApiOkResponse({ description: '일기 조회 성공' })
+  async findDiary(
+    @Param('id', ParseIntPipe) id: number,
+    @User() user: UserEntity,
+  ): Promise<GetDiaryResponseDto> {
+    const diary = await this.diariesService.findDiary(user, id);
+
+    return {
+      userId: diary.author.id,
+      authorName: diary.author.nickname,
+      title: diary.title,
+      content: diary.content,
+      thumbnail: diary.thumbnail,
+      emotion: diary.emotion,
+      mood: diary.mood,
+      keywords: diary.tags?.map((t) => t.name),
+      reactionCount: null,
+    };
+  }
 
   @Post()
   @UseGuards(JwtAuthGuard)

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -24,12 +24,13 @@ export class DiariesController {
   @Get('/:id')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '일기 조회 API' })
-  @ApiOkResponse({ description: '일기 조회 성공' })
+  @ApiOkResponse({ description: '일기 조회 성공', type: GetDiaryResponseDto })
   async findDiary(
     @Param('id', ParseIntPipe) id: number,
     @User() user: UserEntity,
   ): Promise<GetDiaryResponseDto> {
     const diary = await this.diariesService.findDiary(user, id);
+    const tags = await diary.tags;
 
     return {
       userId: diary.author.id,
@@ -39,7 +40,7 @@ export class DiariesController {
       thumbnail: diary.thumbnail,
       emotion: diary.emotion,
       mood: diary.mood,
-      tags: diary.tags?.map((t) => t.name),
+      tags: tags.map((t) => t.name),
       reactionCount: null,
     };
   }

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -27,9 +27,6 @@ export class DiariesRepository extends Repository<Diary> {
   }
 
   async findById(id: number) {
-    return await this.createQueryBuilder('diary')
-      .leftJoinAndSelect('diary.author', 'author')
-      .where('diary.id = :id', { id })
-      .getOne();
+    return await this.createQueryBuilder('diary').where('diary.id = :id', { id }).getOne();
   }
 }

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -14,6 +14,22 @@ export class DiariesRepository extends Repository<Diary> {
   async saveDiary(user: User, createDiaryDto: CreateDiaryDto, tags: Tag[]): Promise<Diary> {
     const { title, content, thumbnail, emotion, mood, status } = createDiaryDto;
 
-    return await this.save({ title, content, thumbnail, emotion, mood, tags, status, user });
+    return await this.save({
+      title,
+      content,
+      thumbnail,
+      emotion,
+      mood,
+      tags,
+      status,
+      user,
+    });
+  }
+
+  async findById(id: number) {
+    return await this.createQueryBuilder('diary')
+      .leftJoinAndSelect('diary.author', 'author')
+      .where('diary.id = :id', { id })
+      .getOne();
   }
 }

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -22,7 +22,7 @@ export class DiariesRepository extends Repository<Diary> {
       mood,
       tags,
       status,
-      user,
+      author: user,
     });
   }
 

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { DiariesRepository } from './diaries.repository';
 import { CreateDiaryDto } from './dto/diary.dto';
 import { User } from 'src/users/entity/user.entity';
@@ -22,10 +22,10 @@ export class DiariesService {
     const diary = await this.diariesRepository.findById(id);
 
     if (!diary) {
-      throw new Error('존재하지 않는 일기입니다.');
+      throw new BadRequestException('존재하지 않는 일기입니다.');
     }
     if (diary.status === DiaryStatus.PRIVATE && diary.author.id !== user.id) {
-      throw new Error('조회 권한이 없는 사용자입니다.');
+      throw new ForbiddenException('조회 권한이 없는 사용자입니다.');
     }
 
     return diary;

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -3,6 +3,7 @@ import { DiariesRepository } from './diaries.repository';
 import { CreateDiaryDto } from './dto/diary.dto';
 import { User } from 'src/users/entity/user.entity';
 import { TagsService } from 'src/tags/tags.service';
+import { DiaryStatus } from './entity/diaryStatus';
 
 @Injectable()
 export class DiariesService {
@@ -15,5 +16,18 @@ export class DiariesService {
     const tags = await this.tagsService.mapTagNameToTagType(createDiaryDto.tagNames);
 
     await this.diariesRepository.saveDiary(user, createDiaryDto, tags);
+  }
+
+  async findDiary(user: User, id: number) {
+    const diary = await this.diariesRepository.findById(id);
+    console.log(diary);
+    if (!diary) {
+      throw new Error('존재하지 않는 일기입니다.');
+    }
+    if (diary.status === DiaryStatus.PRIVATE && diary.author.id !== user.id) {
+      throw new Error('조회 권한이 없는 사용자입니다.');
+    }
+
+    return diary;
   }
 }

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -20,14 +20,14 @@ export class DiariesService {
 
   async findDiary(user: User, id: number) {
     const diary = await this.diariesRepository.findById(id);
+    const author = await diary.author;
 
     if (!diary) {
       throw new BadRequestException('존재하지 않는 일기입니다.');
     }
-    if (diary.status === DiaryStatus.PRIVATE && diary.author.id !== user.id) {
+    if (diary.status === DiaryStatus.PRIVATE && author.id !== user.id) {
       throw new ForbiddenException('조회 권한이 없는 사용자입니다.');
     }
-
     return diary;
   }
 }

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -20,7 +20,7 @@ export class DiariesService {
 
   async findDiary(user: User, id: number) {
     const diary = await this.diariesRepository.findById(id);
-    console.log(diary);
+
     if (!diary) {
       throw new Error('존재하지 않는 일기입니다.');
     }

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -32,22 +32,31 @@ export class CreateDiaryDto {
   status: DiaryStatus;
 }
 
-export interface GetDiaryResponseDto {
+export class GetDiaryResponseDto {
+  @ApiProperty({ description: '작성자 ID' })
   userId: number;
 
+  @ApiProperty({ description: '작성자 닉네임' })
   authorName: string;
 
+  @ApiProperty({ description: '일기 제목' })
   title: string;
 
+  @ApiProperty({ description: '일기 내용' })
   content: string;
 
+  @ApiProperty({ description: '일기 썸네일' })
   thumbnail: string;
 
+  @ApiProperty({ description: '감정(이모지)' })
   emotion: string;
 
+  @ApiProperty({ description: '사용자의 기분(a ~ b 사이의 실수 값)' })
   mood: number;
 
+  @ApiProperty({ description: '일기 태그 배열' })
   tags: string[];
 
+  @ApiProperty({ description: '해당 글의 리액션 갯수' })
   reactionCount: number;
 }

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -31,3 +31,23 @@ export class CreateDiaryDto {
   @ApiProperty({ description: '공개/비공개 여부' })
   status: DiaryStatus;
 }
+
+export interface GetDiaryResponseDto {
+  userId: number;
+
+  authorName: string;
+
+  title: string;
+
+  content: string;
+
+  thumbnail: string;
+
+  emotion: string;
+
+  mood: number;
+
+  keywords: string[];
+
+  reactionCount: number;
+}

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -47,7 +47,7 @@ export interface GetDiaryResponseDto {
 
   mood: number;
 
-  keywords: string[];
+  tags: string[];
 
   reactionCount: number;
 }

--- a/backend/src/diaries/entity/diary.entity.ts
+++ b/backend/src/diaries/entity/diary.entity.ts
@@ -37,7 +37,7 @@ export class Diary extends BaseEntity {
   @Column()
   status: DiaryStatus;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { nullable: false })
   author: User;
 
   @ManyToMany(() => Tag, { cascade: true })

--- a/backend/src/diaries/entity/diary.entity.ts
+++ b/backend/src/diaries/entity/diary.entity.ts
@@ -37,10 +37,10 @@ export class Diary extends BaseEntity {
   @Column()
   status: DiaryStatus;
 
-  @ManyToOne(() => User, { nullable: false })
+  @ManyToOne(() => User, { nullable: false, lazy: true })
   author: User;
 
-  @ManyToMany(() => Tag, { cascade: true })
+  @ManyToMany(() => Tag, { cascade: true, lazy: true })
   @JoinTable({
     name: 'diary_tag',
     joinColumn: { name: 'diary_id', referencedColumnName: 'id' },


### PR DESCRIPTION
## 이슈 번호

#57

## 완료한 기능 명세

- [x] 일기 조회 API 구현

- 응답 화면

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/f70627a3-a61e-4f84-baf4-1cb31e995f03)

- reactionCount는 ERD 변경 중으로 이후 구현 예정입니다.