### PR TITLE
[BE] 일기 반응 API / 리액션 목록 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { DiariesModule } from './diaries/diaries.module';
 import { UsersModule } from './users/users.module';
 import { TagsModule } from './tags/tags.module';
 import { FriendsModule } from './friends/friends.module';
+import { ReactionsModule } from './reactions/reactions.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { FriendsModule } from './friends/friends.module';
     DiariesModule,
     TagsModule,
     FriendsModule,
+    ReactionsModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/diaries/diaries.module.ts
+++ b/backend/src/diaries/diaries.module.ts
@@ -8,6 +8,6 @@ import { TagsModule } from 'src/tags/tags.module';
   controllers: [DiariesController],
   providers: [DiariesService, DiariesRepository],
   imports: [TagsModule],
-  exports: [DiariesRepository],
+  exports: [DiariesService],
 })
 export class DiariesModule {}

--- a/backend/src/diaries/diaries.module.ts
+++ b/backend/src/diaries/diaries.module.ts
@@ -8,5 +8,6 @@ import { TagsModule } from 'src/tags/tags.module';
   controllers: [DiariesController],
   providers: [DiariesService, DiariesRepository],
   imports: [TagsModule],
+  exports: [DiariesRepository],
 })
 export class DiariesModule {}

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -19,12 +19,12 @@ export class DiariesService {
     await this.diariesRepository.saveDiary(user, createDiaryDto, tags);
   }
 
-  async findDiary(user: User, id: number, readonlyMode: boolean) {
+  async findDiary(user: User, id: number, readMode: boolean) {
     const diary = await this.diariesRepository.findById(id);
     this.existsDiary(diary);
 
     const author = await diary.author;
-    this.checkAuthorization(author, user, diary.status, readonlyMode);
+    this.checkAuthorization(author, user, diary.status, readMode);
 
     return diary;
   }

--- a/backend/src/reactions/dto/reaction.dto.ts
+++ b/backend/src/reactions/dto/reaction.dto.ts
@@ -1,0 +1,6 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class CreateReactionDto {
+  @IsNotEmpty()
+  reaction: string;
+}

--- a/backend/src/reactions/dto/reaction.dto.ts
+++ b/backend/src/reactions/dto/reaction.dto.ts
@@ -5,10 +5,6 @@ export class CreateReactionDto {
   reaction: string;
 }
 
-export class GetReactionResponseDto {
-  reactionList: ReactionInfoResponseDto[];
-}
-
 export class ReactionInfoResponseDto {
   userId: number;
   nickname: string;

--- a/backend/src/reactions/dto/reaction.dto.ts
+++ b/backend/src/reactions/dto/reaction.dto.ts
@@ -4,3 +4,14 @@ export class CreateReactionDto {
   @IsNotEmpty()
   reaction: string;
 }
+
+export class GetReactionResponseDto {
+  reactionList: ReactionInfo[];
+}
+
+export class ReactionInfo {
+  userId: number;
+  nickname: string;
+  profileImage: string;
+  reaction: string;
+}

--- a/backend/src/reactions/dto/reaction.dto.ts
+++ b/backend/src/reactions/dto/reaction.dto.ts
@@ -6,10 +6,10 @@ export class CreateReactionDto {
 }
 
 export class GetReactionResponseDto {
-  reactionList: ReactionInfo[];
+  reactionList: ReactionInfoResponseDto[];
 }
 
-export class ReactionInfo {
+export class ReactionInfoResponseDto {
   userId: number;
   nickname: string;
   profileImage: string;

--- a/backend/src/reactions/entity/reaction.entity.ts
+++ b/backend/src/reactions/entity/reaction.entity.ts
@@ -1,10 +1,10 @@
 import { Diary } from 'src/diaries/entity/diary.entity';
 import { User } from 'src/users/entity/user.entity';
-import { BaseEntity, Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class Reaction extends BaseEntity {
-  @PrimaryColumn()
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -9,11 +9,15 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User as UserEntity } from 'src/users/entity/user.entity';
 import { User } from 'src/users/utils/user.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
-import { CreateReactionDto, GetReactionResponseDto, ReactionInfo } from './dto/reaction.dto';
+import {
+  CreateReactionDto,
+  GetReactionResponseDto,
+  ReactionInfoResponseDto,
+} from './dto/reaction.dto';
 import { ReactionsService } from './reactions.service';
 
 @ApiTags('Reaction API')
@@ -23,16 +27,15 @@ export class ReactionsController {
 
   @Get('/:diaryId')
   @UseGuards(JwtAuthGuard)
-  @UsePipes(ValidationPipe)
   @ApiOperation({ description: '리액션 조회 API' })
-  @ApiCreatedResponse({ description: '리액션 조회 성공' })
+  @ApiOkResponse({ description: '리액션 조회 성공' })
   async getReactions(
     @User() user: UserEntity,
     @Param('diaryId', ParseIntPipe) diaryId: number,
   ): Promise<GetReactionResponseDto> {
     const reactions = await this.reactionsService.getReaction(user, diaryId);
 
-    const reactionList = reactions.map<ReactionInfo>((reaction) => {
+    const reactionList = reactions.map<ReactionInfoResponseDto>((reaction) => {
       return {
         userId: reaction.user.id,
         nickname: reaction.user.nickname,

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   ParseIntPipe,
   Post,
@@ -20,10 +21,28 @@ import { ReactionsService } from './reactions.service';
 export class ReactionsController {
   constructor(private readonly reactionsService: ReactionsService) {}
 
+  @Get('/:diaryId')
+  @UseGuards(JwtAuthGuard)
+  @UsePipes(ValidationPipe)
+  @ApiOperation({ description: '리액션 조회 API' })
+  @ApiCreatedResponse({ description: '리액션 조회 성공' })
+  async getReactions(@User() user: UserEntity, @Param('diaryId', ParseIntPipe) diaryId: number) {
+    const reactions = await this.reactionsService.getReaction(user, diaryId);
+
+    return reactions.map((reaction) => {
+      return {
+        userId: reaction.user.id,
+        nickname: reaction.user.nickname,
+        profileImage: reaction.user.profileImage,
+        reaction: reaction.reaction,
+      };
+    });
+  }
+
   @Post('/:diaryId')
   @UseGuards(JwtAuthGuard)
   @UsePipes(ValidationPipe)
-  @ApiOperation({ description: '일기 리액션 API' })
+  @ApiOperation({ description: '리액션 저장 API' })
   @ApiCreatedResponse({ description: '리액션 저장 성공' })
   async createReaction(
     @User() user: UserEntity,

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -13,7 +13,7 @@ import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User as UserEntity } from 'src/users/entity/user.entity';
 import { User } from 'src/users/utils/user.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
-import { CreateReactionDto } from './dto/reaction.dto';
+import { CreateReactionDto, GetReactionResponseDto, ReactionInfo } from './dto/reaction.dto';
 import { ReactionsService } from './reactions.service';
 
 @ApiTags('Reaction API')
@@ -26,10 +26,13 @@ export class ReactionsController {
   @UsePipes(ValidationPipe)
   @ApiOperation({ description: '리액션 조회 API' })
   @ApiCreatedResponse({ description: '리액션 조회 성공' })
-  async getReactions(@User() user: UserEntity, @Param('diaryId', ParseIntPipe) diaryId: number) {
+  async getReactions(
+    @User() user: UserEntity,
+    @Param('diaryId', ParseIntPipe) diaryId: number,
+  ): Promise<GetReactionResponseDto> {
     const reactions = await this.reactionsService.getReaction(user, diaryId);
 
-    return reactions.map((reaction) => {
+    const reactionList = reactions.map<ReactionInfo>((reaction) => {
       return {
         userId: reaction.user.id,
         nickname: reaction.user.nickname,
@@ -37,6 +40,7 @@ export class ReactionsController {
         reaction: reaction.reaction,
       };
     });
+    return { reactionList };
   }
 
   @Post('/:diaryId')

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -13,11 +13,7 @@ import { ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestj
 import { User as UserEntity } from 'src/users/entity/user.entity';
 import { User } from 'src/users/utils/user.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
-import {
-  CreateReactionDto,
-  GetReactionResponseDto,
-  ReactionInfoResponseDto,
-} from './dto/reaction.dto';
+import { CreateReactionDto, ReactionInfoResponseDto } from './dto/reaction.dto';
 import { ReactionsService } from './reactions.service';
 
 @ApiTags('Reaction API')
@@ -32,7 +28,7 @@ export class ReactionsController {
   async getReactions(
     @User() user: UserEntity,
     @Param('diaryId', ParseIntPipe) diaryId: number,
-  ): Promise<GetReactionResponseDto> {
+  ): Promise<Record<string, ReactionInfoResponseDto[]>> {
     const reactions = await this.reactionsService.getReaction(user, diaryId);
 
     const reactionList = reactions.map<ReactionInfoResponseDto>((reaction) => {

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Body,
+  Controller,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { User as UserEntity } from 'src/users/entity/user.entity';
+import { User } from 'src/users/utils/user.decorator';
+import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
+import { CreateReactionDto } from './dto/reaction.dto';
+import { ReactionsService } from './reactions.service';
+
+@ApiTags('Reaction API')
+@Controller('reactions')
+export class ReactionsController {
+  constructor(private readonly reactionsService: ReactionsService) {}
+
+  @Post('/:diaryId')
+  @UseGuards(JwtAuthGuard)
+  @UsePipes(ValidationPipe)
+  @ApiOperation({ description: '일기 리액션 API' })
+  @ApiCreatedResponse({ description: '리액션 저장 성공' })
+  async createDiary(
+    @User() user: UserEntity,
+    @Param('diaryId', ParseIntPipe) diaryId: number,
+    @Body() createReactionDto: CreateReactionDto,
+  ) {
+    await this.reactionsService.saveReaction(user, diaryId, createReactionDto);
+
+    return '일기에 반응을 남겼습니다.';
+  }
+}

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -25,7 +25,7 @@ export class ReactionsController {
   @UsePipes(ValidationPipe)
   @ApiOperation({ description: '일기 리액션 API' })
   @ApiCreatedResponse({ description: '리액션 저장 성공' })
-  async createDiary(
+  async createReaction(
     @User() user: UserEntity,
     @Param('diaryId', ParseIntPipe) diaryId: number,
     @Body() createReactionDto: CreateReactionDto,

--- a/backend/src/reactions/reactions.module.ts
+++ b/backend/src/reactions/reactions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ReactionsController } from './reactions.controller';
+import { ReactionsService } from './reactions.service';
+import { ReactionsRepository } from './reactions.repository';
+import { DiariesModule } from 'src/diaries/diaries.module';
+
+@Module({
+  controllers: [ReactionsController],
+  providers: [ReactionsService, ReactionsRepository],
+  imports: [DiariesModule],
+})
+export class ReactionsModule {}

--- a/backend/src/reactions/reactions.repository.ts
+++ b/backend/src/reactions/reactions.repository.ts
@@ -1,0 +1,10 @@
+import { DataSource, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Reaction } from './entity/reaction.entity';
+
+@Injectable()
+export class ReactionsRepository extends Repository<Reaction> {
+  constructor(private dataSource: DataSource) {
+    super(Reaction, dataSource.createEntityManager());
+  }
+}

--- a/backend/src/reactions/reactions.repository.ts
+++ b/backend/src/reactions/reactions.repository.ts
@@ -1,10 +1,20 @@
 import { DataSource, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { Reaction } from './entity/reaction.entity';
+import { Diary } from 'src/diaries/entity/diary.entity';
 
 @Injectable()
 export class ReactionsRepository extends Repository<Reaction> {
   constructor(private dataSource: DataSource) {
     super(Reaction, dataSource.createEntityManager());
+  }
+
+  async findByDiary(diary: Diary) {
+    return this.find({
+      where: {
+        diary: { id: diary.id },
+      },
+      relations: ['user'],
+    });
   }
 }

--- a/backend/src/reactions/reactions.repository.ts
+++ b/backend/src/reactions/reactions.repository.ts
@@ -2,11 +2,22 @@ import { DataSource, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { Reaction } from './entity/reaction.entity';
 import { Diary } from 'src/diaries/entity/diary.entity';
+import { User } from 'src/users/entity/user.entity';
 
 @Injectable()
 export class ReactionsRepository extends Repository<Reaction> {
   constructor(private dataSource: DataSource) {
     super(Reaction, dataSource.createEntityManager());
+  }
+
+  findReactionByDiaryAndUserAndReaction(user: User, diary: Diary, reaction: string) {
+    return this.findOne({
+      where: {
+        diary: { id: diary.id },
+        user: { id: user.id },
+        reaction,
+      },
+    });
   }
 
   async findByDiary(diary: Diary) {

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ReactionsRepository } from './reactions.repository';
 import { User } from 'src/users/entity/user.entity';
 import { CreateReactionDto } from './dto/reaction.dto';
@@ -19,6 +19,15 @@ export class ReactionsService {
 
   async saveReaction(user: User, diaryId: number, createReactionDto: CreateReactionDto) {
     const diary = await this.diariesService.findDiary(user, diaryId, true);
+
+    const duplicateReaction = await this.reactionsRepository.findReactionByDiaryAndUserAndReaction(
+      user,
+      diary,
+      createReactionDto.reaction,
+    );
+    if (duplicateReaction) {
+      throw new BadRequestException('이미 저장된 리액션 정보입니다.');
+    }
 
     this.reactionsRepository.save({ user, diary, reaction: createReactionDto.reaction });
   }

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -11,6 +11,12 @@ export class ReactionsService {
     private readonly diariesService: DiariesService,
   ) {}
 
+  async getReaction(user: User, diaryId: number) {
+    const diary = await this.diariesService.findDiary(user, diaryId, true);
+
+    return await this.reactionsRepository.findByDiary(diary);
+  }
+
   async saveReaction(user: User, diaryId: number, createReactionDto: CreateReactionDto) {
     const diary = await this.diariesService.findDiary(user, diaryId, true);
 

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -1,21 +1,18 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ReactionsRepository } from './reactions.repository';
 import { User } from 'src/users/entity/user.entity';
 import { CreateReactionDto } from './dto/reaction.dto';
-import { DiariesRepository } from 'src/diaries/diaries.repository';
+import { DiariesService } from 'src/diaries/diaries.service';
 
 @Injectable()
 export class ReactionsService {
   constructor(
     private readonly reactionsRepository: ReactionsRepository,
-    private readonly diariesRepository: DiariesRepository,
+    private readonly diariesService: DiariesService,
   ) {}
 
   async saveReaction(user: User, diaryId: number, createReactionDto: CreateReactionDto) {
-    const diary = await this.diariesRepository.findById(diaryId);
-    if (!diary) {
-      throw new BadRequestException('존재하지 않는 일기 정보입니다.');
-    }
+    const diary = await this.diariesService.findDiary(user, diaryId, true);
 
     this.reactionsRepository.save({ user, diary, reaction: createReactionDto.reaction });
   }

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -1,0 +1,22 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ReactionsRepository } from './reactions.repository';
+import { User } from 'src/users/entity/user.entity';
+import { CreateReactionDto } from './dto/reaction.dto';
+import { DiariesRepository } from 'src/diaries/diaries.repository';
+
+@Injectable()
+export class ReactionsService {
+  constructor(
+    private readonly reactionsRepository: ReactionsRepository,
+    private readonly diariesRepository: DiariesRepository,
+  ) {}
+
+  async saveReaction(user: User, diaryId: number, createReactionDto: CreateReactionDto) {
+    const diary = await this.diariesRepository.findById(diaryId);
+    if (!diary) {
+      throw new BadRequestException('존재하지 않는 일기 정보입니다.');
+    }
+
+    this.reactionsRepository.save({ user, diary, reaction: createReactionDto.reaction });
+  }
+}


### PR DESCRIPTION
## 이슈 번호

#105 

## 완료한 기능 명세

- [x] 일기 반응 API 구현
- [x] 리액션 목록 API 구현

---

- 일기 반응 API

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/44e4fe0b-2134-46b6-bff6-fa36d6dbfe3a)

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/cd5861cb-03a8-49ff-9c9c-90919ad7c498)

특정 사용자가 리액션 버튼 혹은 api로 무수한 요청을 보내는 것을 약간이라도 방지하기 위해서 중복 체크 후 리액션을 저장하도록 구현했습니다.

- 리액션 목록 조회

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/29b27d0b-de58-4e0d-9ca0-a82a09b66480)
