### PR TITLE
[FE] path alias 자동 설정 오류 해결

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,21 +1,15 @@
 module.exports = {
-  extends:"../.eslintrc.js",
+  extends: '../.eslintrc.js',
   env: { browser: true, es2020: true },
-  extends: [
-    "eslint:recommended",
-    "plugin:react-hooks/recommended",
-  ],
-  ignorePatterns: ["dist", ".eslintrc.cjs"],
-  plugins: ["react-refresh"],
+  extends: ['eslint:recommended', 'plugin:react-hooks/recommended'],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  plugins: ['react-refresh'],
   rules: {
-    "react-refresh/only-export-components": [
-      "warn",
-      { allowConstantExport: true },
-    ],
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     'prettier/prettier': [
       'error',
       {
-          endOfLine: 'auto',
+        endOfLine: 'auto',
       },
     ],
   },

--- a/frontend/src/components/Common/DiaryList.tsx
+++ b/frontend/src/components/Common/DiaryList.tsx
@@ -1,5 +1,5 @@
 import DiaryListItem from '@components/Common/DiaryListItem';
-import { IDiaryContent } from '@/src/types/components/Common/DiaryList';
+import { IDiaryContent } from '@type/components/Common/DiaryList';
 
 interface DiaryList {
   pageType: string;

--- a/frontend/src/components/Common/DiaryListItem.tsx
+++ b/frontend/src/components/Common/DiaryListItem.tsx
@@ -5,7 +5,7 @@ import ReactionList from '@components/Diary/ReactionList';
 
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { IDiaryContent } from '@/src/types/components/Common/DiaryList';
+import { IDiaryContent } from '@type/components/Common/DiaryList';
 
 interface DiaryListItemProps {
   pageType?: string;

--- a/frontend/src/components/Home/ProfileEdit.tsx
+++ b/frontend/src/components/Home/ProfileEdit.tsx
@@ -5,7 +5,7 @@ interface ProfileEditProps {
 }
 
 const ProfileEdit = () => {
-  const { profileImage, nickname, userId }: ProfileEditProps = {
+  const { profileImage, nickname }: ProfileEditProps = {
     profileImage:
       'https://mblogthumb-phinf.pstatic.net/MjAyMzA1MDZfMjg2/MDAxNjgzMzY5MzE1MTky.eVMofWydN_T-5Cn227nrfcdyPVzpHRN2jaJXGLeVyUUg.S_l9nnV4ANRX4t9isjrt5rbUd8iWyM8D8w6yJMcPktEg.PNG.withwithpet/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7_2023-05-06_%EC%98%A4%ED%9B%84_7.25.06.png?type=w800',
     nickname: '단디',

--- a/frontend/src/components/MyDiary/ViewType.tsx
+++ b/frontend/src/components/MyDiary/ViewType.tsx
@@ -1,4 +1,4 @@
-import { viewTypes } from '@/src/types/pages/MyDiary';
+import { viewTypes } from '@type/pages/MyDiary';
 
 interface ViewTypeProp {
   viewType: viewTypes;

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -3,12 +3,12 @@ import KeywordSearch from '@components/MyDiary/KeywordSearch';
 import ViewType from '@components/MyDiary/ViewType';
 import { useEffect, useState } from 'react';
 import DiaryListItem from '@components/Common/DiaryListItem';
-import { IDiaryContent } from '../types/components/Common/DiaryList';
-import { viewTypes } from '../types/pages/MyDiary';
-import DateController from '../components/MyDiary/DateController';
-import { getNowMonth } from '../util/MyDiary';
-import Calendar from '../components/MyDiary/Calendar';
-import { dummyData } from '../util/dummyData';
+import { IDiaryContent } from '@type/components/Common/DiaryList';
+import { viewTypes } from '@type/pages/MyDiary';
+import DateController from '@components/MyDiary/DateController';
+import { getNowMonth } from '@util/MyDiary';
+import Calendar from '@components/MyDiary/Calendar';
+import { dummyData } from '@util/dummyData';
 
 const MyDiary = () => {
   const [viewType, setViewType] = useState<viewTypes>('Day');

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
+      "@/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
       "@pages/*": ["./src/pages/*"],
-      "@types/*": ["./src/types/*"],
       "@util/*": ["./src/util/*"],
-      "@asset/*": ["./src/asset/*"],
-      "@api/*": ["./src/api/*"]
+      "@assets/*": ["./src/assets/*"],
+      "@api/*": ["./src/api/*"],
+      "@type/*": ["src/types/*"]
     },
     "target": "ES2020",
     "useDefineForClassFields": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
       '@pages': resolve(__dirname, 'src/pages'),
       '@components': resolve(__dirname, 'src/components'),
       '@assets': resolve(__dirname, 'src/assets'),
-      '@types': resolve(__dirname, 'src/types'),
       '@util': resolve(__dirname, 'src/util'),
       '@api': resolve(__dirname, 'src/api'),
+      '@type': resolve(__dirname, 'src/types'),
     },
   },
 });


### PR DESCRIPTION
## 이슈 번호
close #111

## 완료한 기능 명세
<img width="557" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/8d60e247-d7ea-43fc-ab73-6e9a0d009809">

- `@types`로 설정되었던 alias를 `@type`으로 변경
- `@types`를 `typescript`가 사용하기 때문에 에러가 발생했던 것으로 추측