### PR TITLE
Clova Summary 오류 수정

### DIFF
--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -26,7 +26,6 @@ export class DiariesService {
     diary.summary = await this.getSummary(diary.title, diary.content);
     diary.mood = await this.judgeOverallMood(diary.content);
 
-    console.log(diary);
     await this.diariesRepository.save(diary);
   }
 
@@ -98,6 +97,9 @@ export class DiariesService {
   }
 
   private async getSummary(title: string, content: string) {
+    if (this.isShortContent(content)) {
+      return content;
+    }
     content = content.substring(0, 2000);
 
     const response = await fetch(
@@ -118,6 +120,12 @@ export class DiariesService {
 
     const body = await response.json();
     return body.summary;
+  }
+
+  private isShortContent(content: string) {
+    const sentences = content.split(/[.!?]/).filter((sentence) => sentence.trim() !== '');
+
+    return sentences.length <= 3;
   }
 
   private async judgeOverallMood(fullContent: string) {


### PR DESCRIPTION
## 이슈 번호

#129 

## 완료한 기능 명세

- [x] 3줄 이하의 컨텐츠에 대해서 clova summary에 요청을 보내지 않도록 변경

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/ade567e5-5d4b-48dc-a276-b2a5d1d8b3ab)

- 3줄 이하의 컨텐츠에 대해서는 summary에 본문 내용 자체를 저장하도록 변경했습니다.