### PR TITLE
[BE] emotion 조회 API 요구사항 변경

### DIFF
--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -18,21 +18,20 @@ export class DiariesRepository extends Repository<Diary> {
     });
   }
 
-  async findAllDiaryEmotions(
+  async findAllDiaryBetweenDates(
     userId: number,
     isOwner: boolean,
     startDate: string,
     lastDate: string,
-  ): Promise<GetAllEmotionsResponseDto[]> {
+  ): Promise<Diary[]> {
     const queryBuilder = this.createQueryBuilder('diary')
-      .select(['diary.emotion as emotion', 'COUNT(diary.emotion) as emotionCount'])
       .where('diary.author.id = :userId', { userId })
-      .andWhere('diary.createdAt BETWEEN :startDate AND :lastDate', { startDate, lastDate })
-      .groupBy('diary.emotion');
+      .andWhere('diary.createdAt BETWEEN :startDate AND :lastDate', { startDate, lastDate });
 
     if (!isOwner) {
       queryBuilder.andWhere('diary.status = :status', { status: 'public' });
     }
-    return await queryBuilder.getRawMany();
+
+    return queryBuilder.getMany();
   }
 }

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -98,6 +98,15 @@ export class GetAllEmotionsResponseDto {
   @ApiProperty({ description: '이모지' })
   emotion: string;
 
-  @ApiProperty({ description: '이모지 갯수' })
-  emotionCount: number;
+  @ApiProperty({
+    description: '이모지가 같은 일기 정보 배열',
+    example: [{ id: '1', title: '제목', createdAt: '2023-11-23T02:00:59.661Z' }],
+  })
+  diaryInfos: DiaryInfos[];
+}
+
+class DiaryInfos {
+  id: number;
+  title: string;
+  createdAt: Date;
 }


### PR DESCRIPTION
## 이슈 번호

#131 

## 완료한 기능 명세

- [x] emotion 쿼리 수정
- [x] 반환 타입 변경

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/24a524a0-97d2-4b06-91ec-bf6152e62c30)

- 이모지의 수만 반환하는 것이 아닌 해당 이모지에 연관된 일기의 정보를 함께 반환하도록 변경했습니다.