### PR TITLE
[FE] 잔디 동작 방식 수정

### DIFF
--- a/frontend/src/components/Home/Grass.tsx
+++ b/frontend/src/components/Home/Grass.tsx
@@ -1,5 +1,3 @@
-import { useRef, useEffect, useState } from 'react';
-
 import GrassTooltip from '@components/Home/GrassTooltip';
 
 import { EMOTION_LEVELS, DUMMY_DATA } from '@util/Grass';
@@ -10,9 +8,6 @@ interface GrassDataProps {
 }
 
 const Grass = () => {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const [_, setScrollLeft] = useState(0);
-
   const currentDate: Date = new Date();
   const lastYear: Date = new Date(currentDate);
   lastYear.setFullYear(lastYear.getFullYear() - 1);
@@ -33,13 +28,13 @@ const Grass = () => {
     return `${moodContent} mood on ${tmpDate.toLocaleDateString()}`;
   };
 
-  const renderGrass = (scrollLeft: number) => {
+  const renderGrass = () => {
     return grassData.map((mood, index) => {
       if (mood === undefined) {
         return <div className={`m-[0.1rem] h-4 w-4`}></div>;
       } else {
         return (
-          <GrassTooltip key={index} scrollLeft={scrollLeft} content={getTooltipContent(index)}>
+          <GrassTooltip key={index} content={getTooltipContent(index)}>
             <div className={`m-[0.1rem] h-4 w-4 rounded bg-emotion-${mood}`}></div>
           </GrassTooltip>
         );
@@ -47,26 +42,11 @@ const Grass = () => {
     });
   };
 
-  useEffect(() => {
-    const handleScroll = () => {
-      if (scrollRef.current) {
-        setScrollLeft(scrollRef.current.scrollLeft);
-      }
-    };
-    scrollRef.current?.addEventListener('scroll', handleScroll);
-    return () => {
-      scrollRef.current?.removeEventListener('scroll', handleScroll);
-    };
-  }, []);
-
   return (
     <div className="flex h-full w-3/5 flex-col gap-2 p-5">
       <p className="text-2xl font-bold">지난 1년간 {DUMMY_DATA.length}개의 일기를 작성하셨어요.</p>
-      <div
-        ref={scrollRef}
-        className="grid-rows-7 border-brown grid h-full w-full grid-flow-col overflow-x-scroll rounded-lg border p-2"
-      >
-        {renderGrass(scrollRef.current?.scrollLeft || 0)}
+      <div className="grid-rows-7 border-brown grid h-full w-full grid-flow-col overflow-x-scroll rounded-lg border p-2">
+        {renderGrass()}
       </div>
     </div>
   );

--- a/frontend/src/components/Home/Grass.tsx
+++ b/frontend/src/components/Home/Grass.tsx
@@ -35,11 +35,15 @@ const Grass = () => {
 
   const renderGrass = (scrollLeft: number) => {
     return grassData.map((mood, index) => {
-      return (
-        <GrassTooltip key={index} scrollLeft={scrollLeft} content={getTooltipContent(index)}>
-          <div className={`m-[0.1rem] h-4 w-4 rounded bg-emotion-${mood}`}></div>
-        </GrassTooltip>
-      );
+      if (mood === undefined) {
+        return <div className={`m-[0.1rem] h-4 w-4`}></div>;
+      } else {
+        return (
+          <GrassTooltip key={index} scrollLeft={scrollLeft} content={getTooltipContent(index)}>
+            <div className={`m-[0.1rem] h-4 w-4 rounded bg-emotion-${mood}`}></div>
+          </GrassTooltip>
+        );
+      }
     });
   };
 

--- a/frontend/src/components/Home/Grass.tsx
+++ b/frontend/src/components/Home/Grass.tsx
@@ -11,12 +11,11 @@ const Grass = () => {
   const currentDate: Date = new Date();
   const lastYear: Date = new Date(currentDate);
   lastYear.setFullYear(lastYear.getFullYear() - 1);
-  const dates: number[] = new Array(365).fill(0);
+
+  const dates = Array.from({ length: 365 }, () => 0);
   DUMMY_DATA.forEach(({ date, mood }: GrassDataProps) => {
-    const dataDate: Date = new Date(date);
-    const index: number = Math.floor(
-      (dataDate.getTime() - lastYear.getTime()) / (24 * 60 * 60 * 1000),
-    );
+    const dataDate = new Date(date);
+    const index = Math.floor((dataDate.getTime() - lastYear.getTime()) / (24 * 60 * 60 * 1000));
     dates[index] = mood;
   });
   const grassData = [...Array(lastYear.getDay()).fill(undefined), ...dates];
@@ -28,25 +27,23 @@ const Grass = () => {
     return `${moodContent} mood on ${tmpDate.toLocaleDateString()}`;
   };
 
-  const renderGrass = () => {
-    return grassData.map((mood, index) => {
-      if (mood === undefined) {
-        return <div className={`m-[0.1rem] h-4 w-4`}></div>;
-      } else {
-        return (
-          <GrassTooltip key={index} content={getTooltipContent(index)}>
-            <div className={`m-[0.1rem] h-4 w-4 rounded bg-emotion-${mood}`}></div>
-          </GrassTooltip>
-        );
-      }
-    });
-  };
+  const grassElements = grassData.map((mood, index) => {
+    if (mood === undefined) {
+      return <div key={index} className={`m-[0.1rem] h-4 w-4`}></div>;
+    }
+
+    return (
+      <GrassTooltip key={index} content={getTooltipContent(index)}>
+        <div className={`m-[0.1rem] h-4 w-4 rounded bg-emotion-${mood}`}></div>
+      </GrassTooltip>
+    );
+  });
 
   return (
     <div className="flex h-full w-3/5 flex-col gap-2 p-5">
       <p className="text-2xl font-bold">지난 1년간 {DUMMY_DATA.length}개의 일기를 작성하셨어요.</p>
       <div className="grid-rows-7 border-brown grid h-full w-full grid-flow-col overflow-x-scroll rounded-lg border p-2">
-        {renderGrass()}
+        {grassElements}
       </div>
     </div>
   );

--- a/frontend/src/components/Home/GrassTooltip.tsx
+++ b/frontend/src/components/Home/GrassTooltip.tsx
@@ -1,15 +1,29 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useState, useEffect, useRef } from 'react';
 
 interface GrassTooltipProps {
   content: string;
-  scrollLeft: number;
   children: ReactNode;
 }
 
-const GrassTooltip = ({ content, scrollLeft, children }: GrassTooltipProps) => {
+const GrassTooltip = ({ content, children }: GrassTooltipProps) => {
   const [showTooltip, setShowTooltip] = useState(false);
+  const grassDiv = useRef<HTMLDivElement>(null);
+  const tooltipDiv = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const grassNode = grassDiv.current;
+
+    if (grassNode) {
+      const rect = grassNode.getBoundingClientRect();
+      if (tooltipDiv.current) {
+        tooltipDiv.current.style.left = `${rect.left}px`;
+      }
+    }
+  }, [showTooltip]);
+
   return (
     <div
+      ref={grassDiv}
       className="whitespace-pre"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
@@ -17,8 +31,8 @@ const GrassTooltip = ({ content, scrollLeft, children }: GrassTooltipProps) => {
       {children}
       {showTooltip && (
         <div
-          style={{ transform: `translateX(calc(-50% - ${scrollLeft}px))` }}
-          className="bg-default absolute rounded p-2 text-white opacity-90"
+          ref={tooltipDiv}
+          className="bg-default absolute -translate-x-1/2 rounded p-2 text-white opacity-90"
         >
           {content}
         </div>

--- a/frontend/src/components/Home/GrassTooltip.tsx
+++ b/frontend/src/components/Home/GrassTooltip.tsx
@@ -12,12 +12,10 @@ const GrassTooltip = ({ content, children }: GrassTooltipProps) => {
 
   useEffect(() => {
     const grassNode = grassDiv.current;
-
-    if (grassNode) {
+    const tooltipNode = tooltipDiv.current;
+    if (grassNode && tooltipNode) {
       const rect = grassNode.getBoundingClientRect();
-      if (tooltipDiv.current) {
-        tooltipDiv.current.style.left = `${rect.left}px`;
-      }
+      tooltipNode.style.left = `${rect.left}px`;
     }
   }, [showTooltip]);
 


### PR DESCRIPTION
## 이슈 번호
#142

## 완료한 기능 명세
- mood가 undefined인 경우에도 tooltip이 나오던 문제 해결
- 스크롤 시 전체 잔디가 리렌더링 되던 문제 해결
  - 기존 방식: 스크롤 이벤트로 스크롤의 위치를 가져와 Tooltip을 렌더링 해주는 함수에 인자로 넘겨주어 툴팁의 위치를 수정
  - 변경된 방식: 툴팁에 마우스를 올릴 때 마다 잔디의 위치를 가져와 툴팁의 위치를 변경해주는 방식
