### PR TITLE
[BE] 일기 조회 API 응답 수정

### DIFF
--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -69,11 +69,12 @@ export class DiariesController {
   ): Promise<GetDiaryResponseDto> {
     const diary = await this.diariesService.findDiary(user, id);
     const tags = await diary.tags;
+    const author = await diary.author;
     const reactions = await diary.reactions;
 
     return {
-      userId: diary.author.id,
-      authorName: diary.author.nickname,
+      userId: author.id,
+      authorName: author.nickname,
       title: diary.title,
       content: diary.content,
       thumbnail: diary.thumbnail,

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -75,6 +75,7 @@ export class DiariesController {
     return {
       userId: author.id,
       authorName: author.nickname,
+      profileImage: author.profileImage,
       title: diary.title,
       content: diary.content,
       thumbnail: diary.thumbnail,

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -45,6 +45,9 @@ export class GetDiaryResponseDto {
   @ApiProperty({ description: '작성자 닉네임' })
   authorName: string;
 
+  @ApiProperty({ description: '작성자 프로필 사진 url' })
+  profileImage: string;
+
   @ApiProperty({ description: '일기 제목' })
   title: string;
 


### PR DESCRIPTION
## 이슈 번호

#176 

## 완료한 기능 명세

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/368b7283-4db6-4bd0-8052-d87087582e3a)

- [x] authorId, authorName이 가지 않는 문제 수정
- [x] profileImage 필드 추가
