### PR TITLE
[BE] 친구 목록 조회 API 분리

### DIFF
--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -74,7 +74,7 @@ export class FriendsController {
     await this.friendsService.cancelFriendRequest({ senderId, receiverId: user.id });
     return '친구 신청을 거절했습니다.';
   }
-  
+
   @Get('search/:nickname')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '나의 친구 목록에서 친구 검색' })

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -16,13 +16,24 @@ export class FriendsController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '특정 사용자의 친구 목록 조회' })
   @ApiOkResponse({ description: '친구 목록 조회 성공' })
-  async getFriendsManageList(
+  async getFriendsList(
     @Param('userId', ParseIntPipe) userId: number,
-  ): Promise<Record<string, SearchUserResponseDto[] | StrangerResponseDto[]>> {
+  ): Promise<Record<string, SearchUserResponseDto[]>> {
     const friends = await this.friendsService.getFriendsList(userId);
+
+    return { friends };
+  }
+
+  @Get('request/:userId')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ description: '특정 사용자의 진행 중인 친구신청 목록 조회' })
+  @ApiOkResponse({ description: '진행 중인 친구 신청 조회 성공' })
+  async getFriendRequestList(
+    @Param('userId', ParseIntPipe) userId: number,
+  ): Promise<Record<string, StrangerResponseDto[]>> {
     const strangers = await this.friendsService.getStrangerList(userId);
 
-    return { friends, strangers };
+    return { strangers };
   }
 
   @Post('/:receiverId')

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -41,7 +41,7 @@ export class FriendsService {
     const friendRequest = await this.checkFriendData(friendRelationDto);
     this.friendsRepository.removeRelation(friendRequest);
   }
-  
+
   async allowFriendRequest(friendRelationDto: FriendRelationDto): Promise<void> {
     const friendRequest = await this.checkFriendData(friendRelationDto);
     this.friendsRepository.updateStatus(friendRequest);
@@ -53,16 +53,15 @@ export class FriendsService {
       FriendStatus.COMPLETE,
     );
 
-    const friends: SearchUserResponseDto[] = [];
-    friendRelations.forEach((relation) => {
+    const friends: SearchUserResponseDto[] = friendRelations.map((relation) => {
       const friend = relation.sender.id === userId ? relation.receiver : relation.sender;
 
-      friends.push({
+      return {
         id: friend.id,
         email: friend.email,
         nickname: friend.nickname,
         profileImage: friend.profileImage,
-      });
+      };
     });
 
     return this.sortByNickname(friends);
@@ -74,17 +73,16 @@ export class FriendsService {
       FriendStatus.WAITING,
     );
 
-    const strangers: StrangerResponseDto[] = [];
-    strangerRelations.forEach((relation) => {
+    const strangers: StrangerResponseDto[] = strangerRelations.map((relation) => {
       const stranger = relation.sender.id === userId ? relation.receiver : relation.sender;
 
-      strangers.push({
+      return {
         senderId: relation.sender.id,
         receiverId: relation.receiver.id,
         email: stranger.email,
         nickname: stranger.nickname,
         profileImage: stranger.profileImage,
-      });
+      };
     });
 
     return this.sortByNickname(strangers);


### PR DESCRIPTION
## 이슈 번호

#188 

## 완료한 기능 명세

기존에 친구 목록 조회 시 친구목록과 진행 중인 친구 신청 목록을 같이 조회했는데 이 두가지를 분리함.

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/c21f9244-746f-4dce-8abd-125257347282)

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/3d7b3c1f-dbc3-4e56-842a-7951ba026f4b)
