### PR TITLE
[FE] 홈 페이지 - 친구목록 탭 API 연동

### DIFF
--- a/frontend/src/api/FriendModal.ts
+++ b/frontend/src/api/FriendModal.ts
@@ -13,3 +13,17 @@ export const getFriendList = async (userId: number) => {
     console.log('친구목록 조회에 실패했습니다.', error);
   }
 };
+
+export const recommendFriend = async (nickname: string) => {
+  try {
+    const response = await fetch(API_PATH.FRIEND.search(nickname), {
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('내 친구목록 검색에 실패했습니다.', error);
+  }
+};

--- a/frontend/src/api/FriendModal.ts
+++ b/frontend/src/api/FriendModal.ts
@@ -1,0 +1,15 @@
+import API_PATH from '@util/apiPath';
+
+export const getFriendList = async (userId: number) => {
+  try {
+    const response = await fetch(API_PATH.FRIEND.list(userId), {
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('친구목록 조회에 실패했습니다.', error);
+  }
+};

--- a/frontend/src/components/Home/FriendList.tsx
+++ b/frontend/src/components/Home/FriendList.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { getFriendList, recommendFriend } from '@/api/FriendModal';
+import { getFriendList } from '@api/FriendModal';
 
 import Icon from '@components/Common/Icon';
 import FriendModalItem from '@components/Home/FriendModalItem';
-import { PROFILE_BUTTON_TYPE } from '@/util/constants';
+import FriendSearchContent from '@/components/Home/FriendSearchContent';
+
+import { PROFILE_BUTTON_TYPE } from '@util/constants';
 
 interface FriendListProps {
   userId: number;
@@ -29,16 +31,6 @@ const FriendList = ({ userId }: FriendListProps) => {
     queryKey: ['friendList', userId],
     queryFn: () => getFriendList(userId),
   });
-
-  const recommendData = useQuery({
-    queryKey: ['recommendFriend', nickname],
-    queryFn: () => recommendFriend(nickname),
-    enabled: !!nickname,
-  });
-
-  useEffect(() => {
-    recommendData.refetch();
-  }, [nickname]);
 
   if (friendListData.isLoading) {
     return <p>친구목록 가져오는 중...</p>;
@@ -70,9 +62,9 @@ const FriendList = ({ userId }: FriendListProps) => {
         <div>
           <p className="mb-6 text-2xl font-bold">친구 목록</p>
           <div className="flex flex-wrap justify-between">
-            {friendListData.data.friends.map((data: FriendListResponse) => {
-              <FriendModalItem {...data} type={PROFILE_BUTTON_TYPE.LIST} />;
-            })}
+            {friendListData.data.friends.map((data: FriendListResponse, index: number) => (
+              <FriendModalItem key={index} {...data} type={PROFILE_BUTTON_TYPE.LIST} />
+            ))}
           </div>
         </div>
       )}
@@ -81,10 +73,7 @@ const FriendList = ({ userId }: FriendListProps) => {
         <div>
           <p className="mb-6 text-2xl font-bold">검색 결과</p>
           <div className="flex flex-wrap justify-between">
-            {/* {recommendData &&
-              recommendData.data.map((data: FriendListResponse) => {
-                <FriendModalItem {...data} type={PROFILE_BUTTON_TYPE.LIST} />;
-              })} */}
+            <FriendSearchContent nickname={nickname} />
           </div>
         </div>
       )}

--- a/frontend/src/components/Home/FriendList.tsx
+++ b/frontend/src/components/Home/FriendList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { getFriendList, recommendFriend } from '@/api/FriendModal';
@@ -23,7 +23,6 @@ const FriendList = ({ userId }: FriendListProps) => {
 
   const onChangeNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNickname(e.target.value);
-    recommendData.refetch();
   };
 
   const friendListData = useQuery({
@@ -34,7 +33,12 @@ const FriendList = ({ userId }: FriendListProps) => {
   const recommendData = useQuery({
     queryKey: ['recommendFriend', nickname],
     queryFn: () => recommendFriend(nickname),
+    enabled: !!nickname,
   });
+
+  useEffect(() => {
+    recommendData.refetch();
+  }, [nickname]);
 
   if (friendListData.isLoading) {
     return <p>친구목록 가져오는 중...</p>;
@@ -77,9 +81,10 @@ const FriendList = ({ userId }: FriendListProps) => {
         <div>
           <p className="mb-6 text-2xl font-bold">검색 결과</p>
           <div className="flex flex-wrap justify-between">
-            {recommendData.data.friends.map((data: FriendListResponse) => {
-              <FriendModalItem {...data} type={PROFILE_BUTTON_TYPE.LIST} />;
-            })}
+            {/* {recommendData &&
+              recommendData.data.map((data: FriendListResponse) => {
+                <FriendModalItem {...data} type={PROFILE_BUTTON_TYPE.LIST} />;
+              })} */}
           </div>
         </div>
       )}

--- a/frontend/src/components/Home/FriendList.tsx
+++ b/frontend/src/components/Home/FriendList.tsx
@@ -1,21 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getFriendList } from '@/api/FriendModal';
+
 import Icon from '@components/Common/Icon';
 import FriendModalItem from '@components/Home/FriendModalItem';
+import { PROFILE_BUTTON_TYPE } from '@/util/constants';
 
 interface FriendListProps {
-  email: string;
-  profileImage: string;
-  nickname: string;
-  userId: string;
+  userId: number;
 }
 
-const FriendList = () => {
-  const dummyData: FriendListProps = {
-    profileImage:
-      'https://mblogthumb-phinf.pstatic.net/MjAyMzA1MDZfMjg2/MDAxNjgzMzY5MzE1MTky.eVMofWydN_T-5Cn227nrfcdyPVzpHRN2jaJXGLeVyUUg.S_l9nnV4ANRX4t9isjrt5rbUd8iWyM8D8w6yJMcPktEg.PNG.withwithpet/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7_2023-05-06_%EC%98%A4%ED%9B%84_7.25.06.png?type=w800',
-    nickname: '단디',
-    userId: '1',
-    email: 'dandi@naver.com',
-  };
+interface FriendListResponse {
+  userId: string;
+  email: string;
+  nickname: string;
+  profileImage: string;
+}
+
+const FriendList = ({ userId }: FriendListProps) => {
+  const {
+    data: friendListData,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['friendList', userId],
+    queryFn: () => getFriendList(+userId),
+  });
+
+  if (isLoading) {
+    return <p>친구목록 가져오는 중...</p>;
+  }
+
+  if (isError) {
+    return <p>친구목록을 불러오지 못했습니다!</p>;
+  }
 
   return (
     <div className="px-5">
@@ -36,10 +54,9 @@ const FriendList = () => {
       <div>
         <p className="mb-6 text-2xl font-bold">친구 목록</p>
         <div className="flex flex-wrap justify-between">
-          <FriendModalItem {...dummyData} type="list" />
-          <FriendModalItem {...dummyData} type="list" />
-          <FriendModalItem {...dummyData} type="list" />
-          <FriendModalItem {...dummyData} type="list" />
+          {friendListData.friends.map((data: FriendListResponse) => {
+            <FriendModalItem {...data} type={PROFILE_BUTTON_TYPE.LIST} />;
+          })}
         </div>
       </div>
     </div>

--- a/frontend/src/components/Home/FriendSearchContent.tsx
+++ b/frontend/src/components/Home/FriendSearchContent.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { recommendFriend } from '@api/FriendModal';
+
+import FriendModalItem from '@components/Home/FriendModalItem';
+
+import { PROFILE_BUTTON_TYPE } from '@util/constants';
+
+interface FriendSearchContentProps {
+  nickname: string;
+}
+
+interface FriendListResponse {
+  userId: string;
+  email: string;
+  nickname: string;
+  profileImage: string;
+}
+
+const FriendSearchContent = ({ nickname }: FriendSearchContentProps) => {
+  const recommendData = useQuery({
+    queryKey: ['recommendFriend', nickname],
+    queryFn: () => recommendFriend(nickname),
+    enabled: !!nickname,
+  });
+
+  useEffect(() => {
+    if (nickname !== '') {
+      recommendData.refetch();
+    }
+  }, [nickname]);
+
+  if (recommendData.isLoading) {
+    return <p></p>;
+  }
+
+  if (recommendData.isError) {
+    return <p>친구검색을 불러오지 못했습니다!</p>;
+  }
+
+  return recommendData.data.map((data: FriendListResponse, index: number) => {
+    <FriendModalItem key={index} {...data} type={PROFILE_BUTTON_TYPE.LIST} />;
+  });
+};
+
+export default FriendSearchContent;

--- a/frontend/src/components/Home/Profile.tsx
+++ b/frontend/src/components/Home/Profile.tsx
@@ -57,7 +57,7 @@ const Profile = ({ userId }: ProfileProps) => {
   const getModalContent = (type: string) => {
     switch (type) {
       case PROFILE_MODAL_CONTENT_TYPE.LIST:
-        return <FriendList />;
+        return <FriendList userId={userId} />;
       case PROFILE_MODAL_CONTENT_TYPE.REQUEST:
         return <FriendRequest />;
       case PROFILE_MODAL_CONTENT_TYPE.EDIT:


### PR DESCRIPTION
## 이슈 번호
#150 

## 완료한 기능 명세
- 친구목록 조회 API 연동
- 친구목록 검색 API 연동

## 전해드릴 말
검색된 친구가 출력되어야 할 부분이 응답값을 확신하지 못해서 현재 주석으로 처리했습니다.
다음 작업인 친구관리 탭을 완성 후 수정하도록 하겠습니다.

## 문제상황 공유
FriendList.tsx에서 마운트 시 실행될  useQuery 중 recommendData 를 받아오는  쿼리를 enabled 옵션으로 nickname이 초기 값일 때 동작하지 않도록 하고
```
  useEffect(() => {
    recommendData.refetch();
  }, [nickname]);
```
useEffect를 사용하여 nickname이 변경될 때 마다 refetch를 받아오도록 했습니다.

하지만 제 생각과 다르게 useEffact가 마운트 시 실행되면서 api주소에 nickname의 초기 값인 `""`이 넘어가서 Bad Request가 발생하고 있습니다.
