### PR TITLE
[BE] 키워드 검색 시 추천 태그 조회 API 구현

### DIFF
--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -41,6 +41,8 @@ export class DiariesService {
 
   async saveDiary(user: User, createDiaryDto: CreateDiaryDto) {
     const tags = await this.tagsService.mapTagNameToTagType(createDiaryDto.tagNames);
+    this.tagsService.updateDataSetScore(user.id, createDiaryDto.tagNames);
+
     const diary = plainToClass(Diary, createDiaryDto, {
       excludePrefixes: ['tag'],
     });
@@ -68,6 +70,8 @@ export class DiariesService {
     const existingDiary = await this.findDiary(user, id);
 
     existingDiary.tags = await this.tagsService.mapTagNameToTagType(updateDiaryDto.tagNames);
+    this.tagsService.updateDataSetScore(user.id, updateDiaryDto.tagNames);
+
     Object.keys(updateDiaryDto).forEach((key) => {
       if (updateDiaryDto[key]) {
         existingDiary[key] = updateDiaryDto[key];

--- a/backend/src/tags/dto/tag.dto.ts
+++ b/backend/src/tags/dto/tag.dto.ts
@@ -1,0 +1,3 @@
+export class RecommendedTagsResponseDto {
+  keywords: string[];
+}

--- a/backend/src/tags/tag.repository.ts
+++ b/backend/src/tags/tag.repository.ts
@@ -1,10 +1,15 @@
 import { DataSource, Repository } from 'typeorm';
 import { Tag } from './entity/tag.entity';
 import { Injectable } from '@nestjs/common';
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import { Redis } from 'ioredis';
 
 @Injectable()
 export class TagsRepository extends Repository<Tag> {
-  constructor(private dataSource: DataSource) {
+  constructor(
+    private dataSource: DataSource,
+    @InjectRedis() private readonly redis: Redis,
+  ) {
     super(Tag, dataSource.createEntityManager());
   }
 
@@ -14,5 +19,21 @@ export class TagsRepository extends Repository<Tag> {
 
   async saveTag(name: string) {
     return await this.save({ name });
+  }
+
+  zscore(key: string, tagName: string) {
+    return this.redis.zscore(key, tagName);
+  }
+
+  zadd(key: string, tagName: string) {
+    return this.redis.zadd(key, 1, tagName);
+  }
+
+  zincrby(key: string, tagName: string) {
+    return this.redis.zincrby(key, 1, tagName);
+  }
+
+  zrange(key: string, startIndex: number, endIndex: number) {
+    return this.redis.zrange(key, startIndex, endIndex);
   }
 }

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { TagsService } from './tags.service';
+
+@Controller('tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+}

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -1,7 +1,22 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { TagsService } from './tags.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
+import { User as UserEntity } from 'src/users/entity/user.entity';
+import { RecommendedTagsResponseDto } from './dto/tag.dto';
+import { User } from 'src/users/utils/user.decorator';
 
 @Controller('tags')
 export class TagsController {
   constructor(private readonly tagsService: TagsService) {}
+
+  @Get('search/:keyword')
+  @UseGuards(JwtAuthGuard)
+  async recommendKeywords(
+    @User() user: UserEntity,
+    @Param('keyword') keyword: string,
+  ): Promise<RecommendedTagsResponseDto> {
+    const keywords = await this.tagsService.recommendKeywords(user.id, keyword);
+
+    return { keywords };
+  }
 }

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -13,7 +13,7 @@ export class TagsController {
   @Get('search/:keyword')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '추천 키워드 조회 API' })
-  @ApiOkResponse({ description: '추천 키워드 조회 성공' })
+  @ApiOkResponse({ description: '추천 키워드 조회 성공', type: RecommendedTagsResponseDto })
   async recommendKeywords(
     @User() user: UserEntity,
     @Param('keyword') keyword: string,

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -4,6 +4,7 @@ import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
 import { User as UserEntity } from 'src/users/entity/user.entity';
 import { RecommendedTagsResponseDto } from './dto/tag.dto';
 import { User } from 'src/users/utils/user.decorator';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 @Controller('tags')
 export class TagsController {
@@ -11,6 +12,8 @@ export class TagsController {
 
   @Get('search/:keyword')
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ description: '추천 키워드 조회 API' })
+  @ApiOkResponse({ description: '추천 키워드 조회 성공' })
   async recommendKeywords(
     @User() user: UserEntity,
     @Param('keyword') keyword: string,

--- a/backend/src/tags/tags.module.ts
+++ b/backend/src/tags/tags.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TagsRepository } from './tag.repository';
 import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
 
 @Module({
+  controllers: [TagsController],
   providers: [TagsService, TagsRepository],
   exports: [TagsService],
 })

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { TagsRepository } from '../tags/tag.repository';
-import { InjectRedis } from '@liaoliaots/nestjs-redis';
-import { Redis } from 'ioredis';
+// import { InjectRedis } from '@liaoliaots/nestjs-redis';
+// import { Redis } from 'ioredis';
 
 @Injectable()
 export class TagsService {
   constructor(
     private readonly tagsRepository: TagsRepository,
-    @InjectRedis() private readonly redis: Redis,
+    // @InjectRedis() private readonly redis: Redis,
   ) {}
 
   async mapTagNameToTagType(tagNames: string[]) {
@@ -27,18 +27,18 @@ export class TagsService {
 
   updateDataSetScore(userId: number, tagNames: string[]) {
     tagNames.forEach(async (tag) => {
-      const tagScore = await this.redis.zscore(`${userId}`, tag);
+      const tagScore = await this.tagsRepository.zscore(`${userId}`, tag);
 
       if (!tagScore) {
-        this.redis.zadd(`${userId}`, 1, tag); // 데이터셋에 추가
+        this.tagsRepository.zadd(`${userId}`, tag); // 데이터셋에 추가
       } else {
-        this.redis.zincrby(`${userId}`, 1, tag); // 점수 +1
+        this.tagsRepository.zincrby(`${userId}`, tag); // 점수 +1
       }
     });
   }
 
   async recommendKeywords(userId: number, keyword: string) {
-    const tags = await this.redis.zrange(`${userId}`, 0, -1);
+    const tags = await this.tagsRepository.zrange(`${userId}`, 0, -1);
     const keywords = tags.filter((tag) => tag.includes(keyword));
 
     return keywords.reverse();

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -36,4 +36,11 @@ export class TagsService {
       }
     });
   }
+
+  async recommendKeywords(userId: number, keyword: string) {
+    const tags = await this.redis.zrange(`${userId}`, 0, -1);
+    const keywords = tags.filter((tag) => tag.includes(keyword));
+
+    return keywords.reverse();
+  }
 }


### PR DESCRIPTION
## 이슈 번호

#166 

## 완료한 기능 명세

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/0d3b4a66-f4ca-4f84-bbb9-4899302706d5)

일기를 작성 & 수정할 때 사용한 tag를 redis에 저장합니다. 저장할 때 key를 사용자 id로 한 dataset에 저장하며 sorted set을 사용하여 tag를 한 번 사용할 때 마다 score를 +1씩 해줍니다.

태그 추천은 input keyword를 포함하고 있는 tag들을 score가 높은 순으로 반환합니다.
