### PR TITLE
[BE] 특정 사용자의 일기 조회 API 요청 파라미터 수정

### DIFF
--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -41,7 +41,7 @@ export class DiariesRepository extends Repository<Diary> {
     authorId: number,
     isOwner: boolean,
     startDate: string,
-    lastDate: string,
+    lastDate: Date,
   ) {
     const queryBuilder = this.createQueryBuilder('diary')
       .leftJoin('diary.tags', 'tags')

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -25,10 +25,12 @@ export class DiariesRepository extends Repository<Diary> {
       .where('diary.author.id = :authorId', {
         authorId,
       })
-      .andWhere('diary.id < :lastIndex', { lastIndex })
       .orderBy('diary.id', 'DESC')
       .limit(ITEM_PER_PAGE);
 
+    if (lastIndex) {
+      queryBuilder.andWhere('diary.id < :lastIndex', { lastIndex });
+    }
     if (!isOwner) {
       queryBuilder.andWhere('diary.status = :status', { status: 'public' });
     }

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -76,11 +76,7 @@ export class DiariesRepository extends Repository<Diary> {
     return queryBuilder.getMany();
   }
 
-  async findPaginatedDiaryByDateAndIdList(
-    date: Date,
-    idList: number[],
-    lastIndex: number | undefined,
-  ) {
+  async findPaginatedDiaryByDateAndIdList(date: Date, idList: number[], lastIndex: number) {
     const queryBuilder = this.createQueryBuilder('diary')
       .leftJoinAndSelect('diary.author', 'user')
       .leftJoinAndSelect('diary.tags', 'tags')
@@ -92,8 +88,8 @@ export class DiariesRepository extends Repository<Diary> {
       .orderBy('diary.id', 'DESC')
       .limit(PAGINATION_SIZE);
 
-    if (lastIndex !== undefined) {
-      queryBuilder.where('diary.id < :lastIndex', { lastIndex });
+    if (lastIndex) {
+      queryBuilder.andWhere('diary.id < :lastIndex', { lastIndex });
     }
 
     return await queryBuilder.getMany();

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -21,7 +21,8 @@ export class DiariesRepository extends Repository<Diary> {
   async findDiariesByAuthorIdWithPagination(authorId: number, isOwner: boolean, lastIndex: number) {
     const queryBuilder = this.createQueryBuilder('diary')
       .leftJoin('diary.tags', 'tags')
-      .leftJoin('diary.reactions', 'reactions')
+      .leftJoinAndSelect('diary.reactions', 'reactions')
+      .leftJoinAndSelect('reactions.diary', 'user')
       .where('diary.author.id = :authorId', {
         authorId,
       })

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -22,7 +22,7 @@ export class DiariesRepository extends Repository<Diary> {
     const queryBuilder = this.createQueryBuilder('diary')
       .leftJoin('diary.tags', 'tags')
       .leftJoinAndSelect('diary.reactions', 'reactions')
-      .leftJoinAndSelect('reactions.diary', 'user')
+      .leftJoinAndSelect('reactions.user', 'user')
       .where('diary.author.id = :authorId', {
         authorId,
       })
@@ -46,7 +46,8 @@ export class DiariesRepository extends Repository<Diary> {
   ) {
     const queryBuilder = this.createQueryBuilder('diary')
       .leftJoin('diary.tags', 'tags')
-      .leftJoin('diary.reactions', 'reactions')
+      .leftJoinAndSelect('diary.reactions', 'reactions')
+      .leftJoinAndSelect('reactions.user', 'user')
       .where('diary.author.id = :authorId', { authorId })
       .andWhere('diary.createdAt BETWEEN :startDate AND :lastDate', { startDate, lastDate })
       .orderBy('diary.id', 'DESC');

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -27,7 +27,7 @@ import {
 import { FriendsService } from 'src/friends/friends.service';
 import { TimeUnit } from './dto/timeUnit.enum';
 import { UsersService } from 'src/users/users.service';
-import { subYears } from 'date-fns';
+import { addDays, parseISO, subYears } from 'date-fns';
 import { load } from 'cheerio';
 
 @Injectable()
@@ -191,11 +191,12 @@ export class DiariesService {
         requestDto.lastIndex,
       );
     } else {
+      const endDate = addDays(parseISO(requestDto.endDate), 1);
       diaries = await this.diariesRepository.findDiariesByAuthorIdWithDates(
         id,
         user.id === id,
         requestDto.startDate,
-        requestDto.endDate,
+        endDate,
       );
     }
 

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -213,7 +213,8 @@ export class ReadUserDiariesRequestDto {
   @ValidateIf((o) => o.type === TimeUnit.Day)
   @Type(() => Number)
   @IsNumber()
-  lastIndex: number;
+  @IsOptional()
+  lastIndex: number | null;
 }
 
 export class ReadUserDiariesResponseDto {


### PR DESCRIPTION
## 이슈 번호

#206

## 완료한 기능 명세

- [x] 요청 파라미터 nullable 설정
- [x] endDate가 현재 일자를 포함한 데이터를 포함하도록 변경

---

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/41292131-8b14-4e82-abca-3a17bb34cf25)

lastIndex가 null 인 경우에도 마지막 값부터 일기를 조회할 수 있도록 수정했습니다.
