### PR TITLE
[BE] 토큰 관리 로직 수정 & 로그아웃 API 구현

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -47,6 +47,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
+    "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1"
   },

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Post, Req, Res } from '@nestjs/common';
-import { ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiResponse, ApiOkResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { Request, Response } from 'express';
 import { OAuthLoginDto, OAuthLoginResponseDto } from './dto/auth.dto';
@@ -13,7 +13,7 @@ export class AuthController {
   @ApiOperation({
     description: 'Oauth 로그인 검증 및 토큰 발급 API',
   })
-  @ApiResponse({ status: 200, description: '소셜 로그인 성공', type: OAuthLoginResponseDto })
+  @ApiOkResponse({ description: '소셜 로그인 성공', type: OAuthLoginResponseDto })
   async oauthLogin(@Body() oauthLoginDto: OAuthLoginDto, @Res() res: Response): Promise<void> {
     const loginResult = await this.authService.login(oauthLoginDto);
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,8 +1,9 @@
 import { Body, Controller, Get, Post, Req, Res } from '@nestjs/common';
-import { ApiOperation, ApiTags, ApiResponse, ApiOkResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { Request, Response } from 'express';
 import { OAuthLoginDto, OAuthLoginResponseDto } from './dto/auth.dto';
+import { SERVICE_URL } from './utils/auth.constant';
 
 @ApiTags('Authentication API')
 @Controller('auth')
@@ -25,11 +26,11 @@ export class AuthController {
   @ApiOperation({
     description: 'access token 갱신 API',
   })
-  @ApiResponse({ status: 200, description: 'Success' })
+  @ApiOkResponse({ description: 'access token 갱신 성공' })
   async refreshAccessToken(@Req() req: Request, @Res() res: Response): Promise<void> {
     const newJwt = await this.authService.refreshAccessToken(req);
 
     res.cookie('utk', newJwt, { httpOnly: true });
-    res.redirect('http://223.130.146.253/');
+    res.redirect(SERVICE_URL);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,9 +11,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('/login')
-  @ApiOperation({
-    description: 'Oauth 로그인 검증 및 토큰 발급 API',
-  })
+  @ApiOperation({ description: 'Oauth 로그인 검증 및 토큰 발급 API' })
   @ApiOkResponse({ description: '소셜 로그인 성공', type: OAuthLoginResponseDto })
   async oauthLogin(@Body() oauthLoginDto: OAuthLoginDto, @Res() res: Response): Promise<void> {
     const loginResult = await this.authService.login(oauthLoginDto);
@@ -23,14 +21,21 @@ export class AuthController {
   }
 
   @Get('refresh_token')
-  @ApiOperation({
-    description: 'access token 갱신 API',
-  })
+  @ApiOperation({ description: 'access token 갱신 API' })
   @ApiOkResponse({ description: 'access token 갱신 성공' })
   async refreshAccessToken(@Req() req: Request, @Res() res: Response): Promise<void> {
     const newJwt = await this.authService.refreshAccessToken(req);
 
     res.cookie('utk', newJwt, { httpOnly: true });
     res.redirect(SERVICE_URL);
+  }
+
+  @Post('logout')
+  @ApiOperation({ description: '로그아웃 API' })
+  @ApiOkResponse({ description: '로그아웃 성공' })
+  logout(@Res() res: Response): string {
+    res.cookie('utk', '', { maxAge: 0 });
+
+    return '정상적으로 로그아웃되었습니다.';
   }
 }

--- a/backend/src/auth/auth.repository.ts
+++ b/backend/src/auth/auth.repository.ts
@@ -11,7 +11,7 @@ export class AuthRepository {
     this.redis.set(accessToken, refreshToken, 'EX', REFRESH_TOKEN_EXPIRE_DATE);
   }
 
-  async getRefreshToken(userId: string): Promise<string> {
-    return await this.redis.get(userId);
+  getRefreshToken(accessToken: string) {
+    return this.redis.get(accessToken);
   }
 }

--- a/backend/src/auth/auth.repository.ts
+++ b/backend/src/auth/auth.repository.ts
@@ -1,13 +1,14 @@
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import Redis from 'ioredis';
 import { REFRESH_TOKEN_EXPIRE_DATE } from './utils/auth.constant';
+import { v4 as uuidv4 } from 'uuid';
 
 export class AuthRepository {
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
-  setRefreshToken(userId: number, socialType: string, refreshToken: string): void {
-    const dataForRefresh = { socialType, refreshToken };
-    this.redis.set(`${userId}`, JSON.stringify(dataForRefresh), 'EX', REFRESH_TOKEN_EXPIRE_DATE);
+  setRefreshToken(accessToken: string): void {
+    const refreshToken = uuidv4();
+    this.redis.set(accessToken, refreshToken, 'EX', REFRESH_TOKEN_EXPIRE_DATE);
   }
 
   async getRefreshToken(userId: string): Promise<string> {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -10,9 +10,9 @@ import { User } from '../users/entity/user.entity';
 import { AuthUserDto, LoginResultDto, OAuthLoginDto } from './dto/auth.dto';
 import { Request } from 'express';
 import { cookieExtractor } from './strategy/jwtAuth.strategy';
-import { REFRESH_ACCESS_TOKEN_URL } from './utils/auth.constant';
 import { AuthRepository } from './auth.repository';
 import { SocialType } from 'src/users/entity/socialType';
+import { GET_NAVER_PROFILE_URL, NAVER_OAUTH_URL } from './utils/auth.constant';
 
 @Injectable()
 export class AuthService {
@@ -53,7 +53,7 @@ export class AuthService {
   }
 
   private async getToken(oAuthLoginDto: OAuthLoginDto) {
-    const response = await fetch('https://nid.naver.com/oauth2.0/token', {
+    const response = await fetch(NAVER_OAUTH_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -73,7 +73,7 @@ export class AuthService {
   }
 
   private async getUserProfile(accessToken: string) {
-    const response = await fetch('https://openapi.naver.com/v1/nid/me', {
+    const response = await fetch(GET_NAVER_PROFILE_URL, {
       method: 'GET',
       headers: {
         Authorization: 'Bearer ' + accessToken,
@@ -95,22 +95,16 @@ export class AuthService {
   async refreshAccessToken(req: Request) {
     const userJwt = cookieExtractor(req);
     const payload = this.jwtService.decode(userJwt);
-    const refreshTokenData = JSON.parse(await this.authRepository.getRefreshToken(payload.id));
+    const refreshToken = await this.authRepository.getRefreshToken(userJwt);
 
-    const newData = await fetch(REFRESH_ACCESS_TOKEN_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: this.makeNaverOauthParam(refreshTokenData['refreshToken']),
-    });
-
-    const jsonData = await newData.json();
-    return this.jwtService.sign({
-      id: payload.id,
-      nickname: payload.nickname,
-      accessToken: jsonData['access_token'],
-    });
+    if (refreshToken) {
+      return this.jwtService.sign({
+        id: payload.id,
+        nickname: payload.nickname,
+      });
+    } else {
+      throw new UnauthorizedException('로그인이 필요합니다.');
+    }
   }
 
   private makeNaverOauthParam(refreshToken: string, dto: OAuthLoginDto = null): URLSearchParams {

--- a/backend/src/auth/guards/jwtAuth.guard.ts
+++ b/backend/src/auth/guards/jwtAuth.guard.ts
@@ -28,12 +28,11 @@ export class JwtAuthGuard extends AuthGuard(JWT) {
       } catch (err) {
         if (err.name === JWT_EXPIRED_ERROR) {
           // refresh token 확인
-          const payload = jwtService.decode(userJwt);
           const redis = new Redis(redisConfig);
-          const refreshTokenData = await redis.get(payload.id);
+          const refreshTokenData = await redis.get(userJwt);
 
-          if (refreshTokenData !== null) {
-            // 해당 에러 반환 시 client에서 '/refresh_token'으로 요청 보내기로 함
+          if (refreshTokenData) {
+            // 해당 에러 반환 시 client에서 '/auth/refresh_token'으로 요청 보내기로 함
             throw new ExpiredTokenException();
           }
         }

--- a/backend/src/auth/utils/auth.constant.ts
+++ b/backend/src/auth/utils/auth.constant.ts
@@ -3,4 +3,7 @@ export const JWT_EXPIRE_DATE = '1800s';
 
 // 2주
 export const REFRESH_TOKEN_EXPIRE_DATE = 60 * 60 * 24 * 14;
-export const REFRESH_ACCESS_TOKEN_URL = 'https://nid.naver.com/oauth2.0/token';
+
+export const SERVICE_URL = 'http://223.130.146.253/';
+export const NAVER_OAUTH_URL = 'https://nid.naver.com/oauth2.0/token';
+export const GET_NAVER_PROFILE_URL = 'https://openapi.naver.com/v1/nid/me';

--- a/backend/src/auth/utils/auth.constant.ts
+++ b/backend/src/auth/utils/auth.constant.ts
@@ -4,6 +4,6 @@ export const JWT_EXPIRE_DATE = '1800s';
 // 2주
 export const REFRESH_TOKEN_EXPIRE_DATE = 60 * 60 * 24 * 14;
 
-export const SERVICE_URL = 'http://223.130.146.253/';
+export const SERVICE_URL = 'http://223.130.146.253';
 export const NAVER_OAUTH_URL = 'https://nid.naver.com/oauth2.0/token';
 export const GET_NAVER_PROFILE_URL = 'https://openapi.naver.com/v1/nid/me';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6735,7 +6735,7 @@ uuid@9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==


### PR DESCRIPTION
## 이슈 번호

#164

#211 

## 완료한 기능 명세

- access token과 refresh token을 서비스 자체에서 생성하고 관리하도록 변경했습니다.

- access token은 JWT로 사용자 id, nickname을 담고 있고, refresh token은 UUID입니다.
- redis에 access token을 key, refresh token을 value로 하여 만료기간 2주로 설정하여 저장합니다.
- 로그아웃 시에는 cookie가 만료되도록 했습니다.
- 로직에서 사용되는 URL들은 상수파일로 분리했습니다.
