### PR TITLE
[BE] 태그 기반 일기 조회에 페이지네이션 적용

### DIFF
--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -29,9 +29,9 @@ import {
   ReadUserDiariesRequestDto,
   ReadUserDiariesResponseDto,
   UpdateDiaryDto,
-  getFeedDiaryRequestDto,
-  getFeedDiaryResponseDto,
-  getYearMoodResponseDto,
+  LastIndexDto,
+  GetFeedDiaryResponseDto,
+  GetYearMoodResponseDto,
 } from './dto/diary.dto';
 import { DiariesService } from './diaries.service';
 import { User as UserEntity } from 'src/users/entity/user.entity';
@@ -46,11 +46,11 @@ export class DiariesController {
   @Get('/friends')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '피드 일기 조회 API' })
-  @ApiOkResponse({ description: '피드 일기 조회 성공', type: getFeedDiaryResponseDto })
+  @ApiOkResponse({ description: '피드 일기 조회 성공', type: GetFeedDiaryResponseDto })
   async getFeedDiary(
     @User() user: UserEntity,
-    @Query(ValidationPipe) queryString: getFeedDiaryRequestDto,
-  ): Promise<getFeedDiaryResponseDto> {
+    @Query(ValidationPipe) queryString: LastIndexDto,
+  ): Promise<GetFeedDiaryResponseDto> {
     const [diaryList, lastIndex] = await this.diariesService.getFeedDiary(
       user.id,
       queryString.lastIndex,
@@ -188,11 +188,11 @@ export class DiariesController {
   @ApiOperation({ description: '1년의 일기 mood조회' })
   @ApiCreatedResponse({
     description: '일기 mood 조회 성공',
-    type: [getYearMoodResponseDto],
+    type: [GetYearMoodResponseDto],
   })
   async getMoodForYear(
     @Param('userId', ParseIntPipe) userId: number,
-  ): Promise<Record<string, getYearMoodResponseDto[]>> {
+  ): Promise<Record<string, GetYearMoodResponseDto[]>> {
     const yearMood = await this.diariesService.getMoodForYear(userId);
 
     return { yearMood };

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -30,8 +30,8 @@ import {
   ReadUserDiariesResponseDto,
   UpdateDiaryDto,
   LastIndexDto,
-  GetFeedDiaryResponseDto,
   GetYearMoodResponseDto,
+  FeedDiaryDto,
 } from './dto/diary.dto';
 import { DiariesService } from './diaries.service';
 import { User as UserEntity } from 'src/users/entity/user.entity';
@@ -46,17 +46,14 @@ export class DiariesController {
   @Get('/friends')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '피드 일기 조회 API' })
-  @ApiOkResponse({ description: '피드 일기 조회 성공', type: GetFeedDiaryResponseDto })
+  @ApiOkResponse({ description: '피드 일기 조회 성공', type: FeedDiaryDto })
   async getFeedDiary(
     @User() user: UserEntity,
     @Query(ValidationPipe) queryString: LastIndexDto,
-  ): Promise<GetFeedDiaryResponseDto> {
-    const [diaryList, lastIndex] = await this.diariesService.getFeedDiary(
-      user.id,
-      queryString.lastIndex,
-    );
+  ): Promise<Record<string, FeedDiaryDto[]>> {
+    const diaryList = await this.diariesService.getFeedDiary(user.id, queryString.lastIndex);
 
-    return { lastIndex, diaryList };
+    return { diaryList };
   }
 
   @Get('/:id')
@@ -240,8 +237,13 @@ export class DiariesController {
   async findDiaryByTag(
     @User() user: UserEntity,
     @Param('tagName') tagName: string,
+    @Query(ValidationPipe) queryString: LastIndexDto,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaryList = await this.diariesService.findDiaryByTag(user.id, tagName);
+    const diaryList = await this.diariesService.findDiaryByTag(
+      user.id,
+      tagName,
+      queryString.lastIndex,
+    );
 
     return { nickname: user.nickname, diaryList };
   }

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -156,14 +156,20 @@ export class DiariesRepository extends Repository<Diary> {
 
     return documents.hits.hits.map((hit) => hit._source as SearchDiaryDataForm);
   }
-  
-  findDiaryByTag(userId: number, tagName: string) {
+
+  findDiaryByTag(userId: number, tagName: string, lastIndex: number) {
     const queryBuilder = this.createQueryBuilder('diary')
       .leftJoinAndSelect('diary.reactions', 'reactions')
       .leftJoinAndSelect('reactions.user', 'reactionUser')
       .innerJoin('diary.tags', 'tags')
       .where('tags.name = :tagName', { tagName })
-      .andWhere('diary.author.id = :userId', { userId });
+      .andWhere('diary.author.id = :userId', { userId })
+      .orderBy('diary.id', 'DESC')
+      .limit(PAGINATION_SIZE);
+
+    if (lastIndex) {
+      queryBuilder.andWhere('diary.id < :lastIndex', { lastIndex });
+    }
 
     return queryBuilder.getMany();
   }

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -136,10 +136,7 @@ export class DiariesService {
     }, []);
   }
 
-  async getFeedDiary(
-    userId: number,
-    lastIndex: number | undefined,
-  ): Promise<[FeedDiaryDto[], number]> {
+  async getFeedDiary(userId: number, lastIndex: number | undefined): Promise<FeedDiaryDto[]> {
     const today = new Date();
     const oneWeekAgo = new Date(today);
     oneWeekAgo.setDate(today.getDate() - 7);
@@ -177,11 +174,7 @@ export class DiariesService {
       }),
     );
 
-    if (diaries.length > 0) {
-      lastIndex = diaries[0].id;
-    }
-
-    return [feedDiaryList, lastIndex];
+    return feedDiaryList;
   }
 
   async findDiaryByAuthorId(user: User, id: number, requestDto: ReadUserDiariesRequestDto) {
@@ -225,8 +218,8 @@ export class DiariesService {
     return this.makeAllDiaryInfosDto(diaries, author.id);
   }
 
-  async findDiaryByTag(userId: number, tagName: string) {
-    const diaries = await this.diariesRepository.findDiaryByTag(userId, tagName);
+  async findDiaryByTag(userId: number, tagName: string, lastIndex: number | undefined) {
+    const diaries = await this.diariesRepository.findDiaryByTag(userId, tagName, lastIndex);
 
     return this.makeAllDiaryInfosDto(diaries, userId);
   }

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -4,7 +4,7 @@ import {
   CreateDiaryDto,
   FeedDiaryDto,
   GetAllEmotionsRequestDto,
-  getYearMoodResponseDto,
+  GetYearMoodResponseDto,
   GetAllEmotionsResponseDto,
   ReadUserDiariesRequestDto,
   UpdateDiaryDto,
@@ -207,12 +207,12 @@ export class DiariesService {
     return { author, diaries };
   }
 
-  async getMoodForYear(userId: number): Promise<getYearMoodResponseDto[]> {
+  async getMoodForYear(userId: number): Promise<GetYearMoodResponseDto[]> {
     const oneYearAgo = subYears(new Date(), 1);
 
     const diariesForYear = await this.diariesRepository.findLatestDiaryByDate(userId, oneYearAgo);
 
-    const yearMood: getYearMoodResponseDto[] = diariesForYear.reduce((acc, cur) => {
+    const yearMood: GetYearMoodResponseDto[] = diariesForYear.reduce((acc, cur) => {
       return [...acc, { date: cur.createdAt, mood: cur.mood }];
     }, []);
 

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -131,7 +131,7 @@ class DiaryInfos {
   createdAt: Date;
 }
 
-export class getFeedDiaryRequestDto {
+export class LastIndexDto {
   @ApiProperty({ description: '커서 방식 페이지네이션을 위한 diary Index' })
   @IsOptional()
   @IsInt()
@@ -174,7 +174,7 @@ export class FeedDiaryDto {
   leavedReaction: string | null;
 }
 
-export class getFeedDiaryResponseDto {
+export class GetFeedDiaryResponseDto {
   @ApiProperty({ description: '마지막으로 조회한 일기 id' })
   lastIndex: number;
 
@@ -252,7 +252,7 @@ export class AllDiaryInfosDto {
   leavedReaction?: string;
 }
 
-export class getYearMoodResponseDto {
+export class GetYearMoodResponseDto {
   @ApiProperty({ description: '날짜' })
   date: Date;
 

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -174,30 +174,6 @@ export class FeedDiaryDto {
   leavedReaction: string | null;
 }
 
-export class GetFeedDiaryResponseDto {
-  @ApiProperty({ description: '마지막으로 조회한 일기 id' })
-  lastIndex: number;
-
-  @ApiProperty({
-    description: '친구 일기 배열',
-    example: [
-      {
-        diaryId: 1,
-        createdAt: '2023-11-25T13:56:02.027Z',
-        profileImage: 'aldskf',
-        nickname: 'cuhyun',
-        thumbnail: null,
-        title: '카페에서 공부한 날',
-        summary: '카공은 즐거워',
-        tags: ['카페'],
-        reactionCount: 2,
-        leavedReaction: '🥤',
-      },
-    ],
-  })
-  diaryList: FeedDiaryDto[];
-}
-
 export class ReadUserDiariesRequestDto {
   @IsIn(Object.values(TimeUnit))
   type: TimeUnit;


### PR DESCRIPTION
## 이슈 번호

#167

## 완료한 기능 명세

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/449991c7-447b-49cd-94eb-9adcb838cc14)

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/1ed44e0f-8dc4-4b03-93ce-32b2dfb2fbf2)

- 페이지네이션 적용
- lastIndex return하는 부분 삭제