### PR TITLE
[BE] 검색 API 페이징 처리 | Full Text Index 적용

### DIFF
--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -208,24 +208,43 @@ export class DiariesController {
   async findDiaryByKeywordV1(
     @User() author: UserEntity,
     @Param('keyword') keyword: string,
+    @Query('lastIndex') lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaryList = await this.diariesService.findDiaryByKeywordV1(author, keyword);
+    const diaryList = await this.diariesService.findDiaryByKeywordV1(author, keyword, lastIndex);
 
     return { nickname: author.nickname, diaryList };
   }
 
   @Get('/search/v2/:keyword')
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ description: '키워드로 일기 검색(Elasticsearch)' })
-  @ApiOkResponse({
+  @ApiOperation({ description: '키워드로 일기 검색(MySQL Full Text Index)' })
+  @ApiCreatedResponse({
     description: '일기 검색 성공',
     type: ReadUserDiariesResponseDto,
   })
   async findDiaryByKeywordV2(
     @User() author: UserEntity,
     @Param('keyword') keyword: string,
+    @Query('lastIndex') lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaryList = await this.diariesService.findDiaryByKeywordV2(author, keyword);
+    const diaryList = await this.diariesService.findDiaryByKeywordV1(author, keyword, lastIndex);
+
+    return { nickname: author.nickname, diaryList };
+  }
+
+  @Get('/search/v3/:keyword')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ description: '키워드로 일기 검색(Elasticsearch)' })
+  @ApiOkResponse({
+    description: '일기 검색 성공',
+    type: ReadUserDiariesResponseDto,
+  })
+  async findDiaryByKeywordV3(
+    @User() author: UserEntity,
+    @Param('keyword') keyword: string,
+    @Query('lastIndex') lastIndex: number,
+  ): Promise<ReadUserDiariesResponseDto> {
+    const diaryList = await this.diariesService.findDiaryByKeywordV3(author, keyword, lastIndex);
 
     return { nickname: author.nickname, diaryList };
   }

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -227,7 +227,7 @@ export class DiariesController {
     @Param('keyword') keyword: string,
     @Query('lastIndex') lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaryList = await this.diariesService.findDiaryByKeywordV1(author, keyword, lastIndex);
+    const diaryList = await this.diariesService.findDiaryByKeywordV2(author, keyword, lastIndex);
 
     return { nickname: author.nickname, diaryList };
   }

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -208,7 +208,7 @@ export class DiariesController {
   async findDiaryByKeywordV1(
     @User() author: UserEntity,
     @Param('keyword') keyword: string,
-    @Query('lastIndex') lastIndex: number,
+    @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
     const diaryList = await this.diariesService.findDiaryByKeywordV1(author, keyword, lastIndex);
 
@@ -225,8 +225,9 @@ export class DiariesController {
   async findDiaryByKeywordV2(
     @User() author: UserEntity,
     @Param('keyword') keyword: string,
-    @Query('lastIndex') lastIndex: number,
+    @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
+    console.log(typeof lastIndex);
     const diaryList = await this.diariesService.findDiaryByKeywordV2(author, keyword, lastIndex);
 
     return { nickname: author.nickname, diaryList };
@@ -242,7 +243,7 @@ export class DiariesController {
   async findDiaryByKeywordV3(
     @User() author: UserEntity,
     @Param('keyword') keyword: string,
-    @Query('lastIndex') lastIndex: number,
+    @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
     const diaryList = await this.diariesService.findDiaryByKeywordV3(author, keyword, lastIndex);
 

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -153,7 +153,7 @@ export class DiariesRepository extends Repository<Diary> {
         query: {
           bool: {
             must: [
-              { term: { authorid: 2 } },
+              { term: { authorid: id } },
               {
                 bool: {
                   should: [{ match: { content: keyword } }, { match: { title: keyword } }],
@@ -166,7 +166,6 @@ export class DiariesRepository extends Repository<Diary> {
       },
     });
 
-    console.log(documents.hits.hits);
     return documents.hits.hits.map((hit) => hit._source as SearchDiaryDataForm);
   }
 

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -229,6 +229,16 @@ export class DiariesService {
     return this.makeAllDiaryInfosDto(diaries, author.id);
   }
 
+  async findDiaryByKeywordV2(author: User, keyword: string, lastIndex: number) {
+    const diaries = await this.diariesRepository.findDiaryByKeywordV2(
+      author.id,
+      keyword,
+      lastIndex,
+    );
+
+    return this.makeAllDiaryInfosDto(diaries, author.id);
+  }
+
   async findDiaryByTag(userId: number, tagName: string) {
     const diaries = await this.diariesRepository.findDiaryByTag(userId, tagName);
 

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -219,8 +219,12 @@ export class DiariesService {
     return yearMood;
   }
 
-  async findDiaryByKeywordV1(author: User, keyword: string) {
-    const diaries = await this.diariesRepository.findDiaryByKeywordV1(author.id, keyword);
+  async findDiaryByKeywordV1(author: User, keyword: string, lastIndex: number) {
+    const diaries = await this.diariesRepository.findDiaryByKeywordV1(
+      author.id,
+      keyword,
+      lastIndex,
+    );
 
     return this.makeAllDiaryInfosDto(diaries, author.id);
   }
@@ -252,8 +256,12 @@ export class DiariesService {
     );
   }
 
-  async findDiaryByKeywordV2(author: User, keyword: string) {
-    const diaries = await this.diariesRepository.findDiaryByKeywordV2(author.id, keyword);
+  async findDiaryByKeywordV3(author: User, keyword: string, lastIndex: number) {
+    const diaries = await this.diariesRepository.findDiaryByKeywordV3(
+      author.id,
+      keyword,
+      lastIndex,
+    );
 
     return diaries.map<AllDiaryInfosDto>((diary) => {
       const reactionIndex = diary.reactionUsers.findIndex((userId) => userId === author.id);

--- a/backend/src/diaries/entity/diary.entity.ts
+++ b/backend/src/diaries/entity/diary.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  Index,
   JoinTable,
   ManyToMany,
   ManyToOne,
@@ -23,9 +24,11 @@ export class Diary extends BaseEntity {
   id: number;
 
   @Column()
+  @Index('idx_diary_title', { fulltext: true })
   title: string;
 
   @Column({ length: 10000 })
+  @Index('idx_diary_content', { fulltext: true })
   content: string;
 
   @Column()


### PR DESCRIPTION
## 이슈 번호

#217 

## 완료한 기능 명세

- [x] search api에 페이징 적용
- [x] search api v2: full text index 적용

---

### 성능 테스트 k6 + grafana

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/17b131a8-e564-4381-8c2a-03d05db9d7c2)

로컬 환경에서 서버를 구동해 간단한 성능 테스트도 해봤습니다.
저도 모든 옵션을 잘 알지는 못해서 `http_req_duration`만 일단 말씀드리면, 예상과 같이 v3(엘라스틱서치)를 사용한 검색 성능이 다른 요청에 비해 1초 가량 빨랐습니다.
다만, 예상치못하게 v2가 v1보다 빠를 줄 알았는데 v1이 약간 더 성능상 이점이 있는 것 같이 보여서 이건 좀 더 학습해봐야할 것 같습니다.!
