### PR TITLE
[FE] 내가 작성한 일기 API 연동 마무리 & 로직 수정, 감정 통계 API 연동

### DIFF
--- a/frontend/src/api/DiaryList.ts
+++ b/frontend/src/api/DiaryList.ts
@@ -1,0 +1,15 @@
+// import API_PATH from '@util/apiPath';
+
+// export const getDiaryListDay = async (userId: number, type: string, lastIndex = 0) => {
+//   try {
+//     const response = await fetch(API_PATH.USER.userProfile(userId), {
+//       credentials: 'include',
+//     });
+
+//     if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+//     const data = await response.json();
+//     return data;
+//   } catch (error) {
+//     console.log('현재 로그인 중인 유저 정보 조회에 실패했습니다.', error);
+//   }
+// };

--- a/frontend/src/api/DiaryList.ts
+++ b/frontend/src/api/DiaryList.ts
@@ -30,7 +30,7 @@ export const getDiaryDayList = async (pageParam: getDiaryDayListProps) => {
     const data = await response.json();
     return data;
   } catch (error) {
-    console.log('현재 로그인 중인 유저 정보 조회에 실패했습니다.', error);
+    console.log('일기 목록 조회에 실패했습니다.', error);
   }
 };
 
@@ -48,6 +48,6 @@ export const getDiaryWeekAndMonthList = async (pageParam: getDiaryWeekAndMonthLi
     const data = await response.json();
     return data;
   } catch (error) {
-    console.log('현재 로그인 중인 유저 정보 조회에 실패했습니다.', error);
+    console.log('일기 목록 조회에 실패했습니다.', error);
   }
 };

--- a/frontend/src/api/DiaryList.ts
+++ b/frontend/src/api/DiaryList.ts
@@ -1,15 +1,53 @@
-// import API_PATH from '@util/apiPath';
+import { viewTypes } from '@type/pages/MyDiary';
 
-// export const getDiaryListDay = async (userId: number, type: string, lastIndex = 0) => {
-//   try {
-//     const response = await fetch(API_PATH.USER.userProfile(userId), {
-//       credentials: 'include',
-//     });
+import API_PATH from '@util/apiPath';
 
-//     if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
-//     const data = await response.json();
-//     return data;
-//   } catch (error) {
-//     console.log('현재 로그인 중인 유저 정보 조회에 실패했습니다.', error);
-//   }
-// };
+interface getDiaryListProps {
+  userId: string;
+  type: viewTypes;
+}
+
+interface getDiaryDayListProps extends getDiaryListProps {
+  lastIndex?: number;
+}
+
+interface getDiaryWeekAndMonthListProps extends getDiaryListProps {
+  startDate: string;
+  endDate: string;
+}
+
+export const getDiaryDayList = async (pageParam: getDiaryDayListProps) => {
+  const { userId, type, lastIndex } = pageParam;
+  try {
+    const fetchUrl = lastIndex
+      ? API_PATH.DIARY.myDiaryDay(userId, type, lastIndex)
+      : API_PATH.DIARY.myDiaryDay(userId, type);
+    const response = await fetch(fetchUrl, {
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('현재 로그인 중인 유저 정보 조회에 실패했습니다.', error);
+  }
+};
+
+export const getDiaryWeekAndMonthList = async (pageParam: getDiaryWeekAndMonthListProps) => {
+  const { userId, type, startDate, endDate } = pageParam;
+  try {
+    const response = await fetch(
+      API_PATH.DIARY.myDiaryWeekAndMonth(userId, type, startDate, endDate),
+      {
+        credentials: 'include',
+      },
+    );
+
+    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('현재 로그인 중인 유저 정보 조회에 실패했습니다.', error);
+  }
+};

--- a/frontend/src/api/DiaryList.ts
+++ b/frontend/src/api/DiaryList.ts
@@ -15,7 +15,6 @@ interface getDiaryWeekAndMonthListProps extends getDiaryListProps {
 export const getDiaryDayList = async ({ pageParam }: any) => {
   try {
     const { userId, type, lastIndex } = pageParam;
-    console.log('어라', userId, type, lastIndex);
     const fetchUrl = lastIndex
       ? API_PATH.DIARY.myDiaryDay(userId, type, lastIndex)
       : API_PATH.DIARY.myDiaryDay(userId, type);

--- a/frontend/src/api/DiaryList.ts
+++ b/frontend/src/api/DiaryList.ts
@@ -7,18 +7,15 @@ interface getDiaryListProps {
   type: viewTypes;
 }
 
-interface getDiaryDayListProps extends getDiaryListProps {
-  lastIndex?: number;
-}
-
 interface getDiaryWeekAndMonthListProps extends getDiaryListProps {
   startDate: string;
   endDate: string;
 }
 
-export const getDiaryDayList = async (pageParam: getDiaryDayListProps) => {
-  const { userId, type, lastIndex } = pageParam;
+export const getDiaryDayList = async ({ pageParam }: any) => {
   try {
+    const { userId, type, lastIndex } = pageParam;
+    console.log('어라', userId, type, lastIndex);
     const fetchUrl = lastIndex
       ? API_PATH.DIARY.myDiaryDay(userId, type, lastIndex)
       : API_PATH.DIARY.myDiaryDay(userId, type);

--- a/frontend/src/api/EmotionStat.ts
+++ b/frontend/src/api/EmotionStat.ts
@@ -1,0 +1,17 @@
+import API_PATH from '@util/apiPath';
+
+const getEmotionStat = async (id: number, startDate: string, endDate: string) => {
+  try {
+    const response = await fetch(API_PATH.DIARY.emotion(id, startDate, endDate), {
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('감정 통계 조회에 실패했습니다.', error);
+  }
+};
+
+export default getEmotionStat;

--- a/frontend/src/components/Common/DiaryList.tsx
+++ b/frontend/src/components/Common/DiaryList.tsx
@@ -5,13 +5,15 @@ import DiaryListItem from '@components/Common/DiaryListItem';
 import { HOME, PAGE_TITLE_HOME, PAGE_TITLE_FEED } from '@util/constants';
 
 interface DiaryList {
-  pageType: string;
+  pageType?: string;
   diaryData: IDiaryContent[];
+  username?: string;
 }
 
-const DiaryList = ({ pageType, diaryData }: DiaryList) => {
+const DiaryList = ({ pageType, diaryData, username }: DiaryList) => {
   const { nickname } = diaryData[0];
-  const pageTitle = pageType === HOME ? `${nickname} ${PAGE_TITLE_HOME}` : PAGE_TITLE_FEED;
+  const pageTitle =
+    pageType === HOME ? `${username ? username : nickname} ${PAGE_TITLE_HOME}` : PAGE_TITLE_FEED;
   const content = diaryData.map((data: IDiaryContent, index) => (
     <DiaryListItem key={index} pageType={pageType} diaryItem={data} />
   ));

--- a/frontend/src/components/Common/DiaryListItem.tsx
+++ b/frontend/src/components/Common/DiaryListItem.tsx
@@ -64,7 +64,7 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
       </div>
 
       <div className="mb-3 flex flex-wrap gap-3 text-base">
-        {diaryItem.keywords.map((keyword, index) => (
+        {diaryItem.tags.map((keyword, index) => (
           <Keyword key={index} text={keyword} />
         ))}
       </div>

--- a/frontend/src/components/Common/NavBar.tsx
+++ b/frontend/src/components/Common/NavBar.tsx
@@ -1,8 +1,7 @@
 import { NavLink, useNavigate } from 'react-router-dom';
+import logo from '@assets/image/logo.svg';
 
 import { logout } from '@api/Login';
-
-import logo from '@assets/image/logo.svg';
 
 const NavBar = () => {
   const navigate = useNavigate();

--- a/frontend/src/components/Common/ProfileItem.tsx
+++ b/frontend/src/components/Common/ProfileItem.tsx
@@ -1,10 +1,11 @@
 import { useNavigate } from 'react-router-dom';
+
 import { PAGE_URL } from '@util/constants';
 
 interface ProfileItemProps {
   id: number;
-  img: string;
-  nickName: string;
+  img?: string;
+  nickName?: string;
 }
 
 const ProfileItem = ({ id, img, nickName }: ProfileItemProps) => {

--- a/frontend/src/components/Edit/KeywordBox.tsx
+++ b/frontend/src/components/Edit/KeywordBox.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import Keyword from '@components/Common/Keyword';
 
 interface KeywordBoxProps {

--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -18,7 +18,7 @@ const calPrevOneWeek = () => {
 const EmotionStat = ({ nickname }: EmotionStatProps) => {
   const [period, _] = useState([calPrevOneWeek(), new Date()]);
 
-  const { data, isError, isLoading } = useQuery({
+  const { isError, isLoading } = useQuery({
     queryKey: ['emotionStat', localStorage.getItem('userId')],
     queryFn: () =>
       getEmotionStat(

--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import getEmotionStat from '@api/EmotionStat';
+
+import { formatDateDash } from '@util/funcs';
+
+interface EmotionStatProps {
+  nickname: string;
+}
+
+const calPrevOneWeek = () => {
+  const date = new Date();
+  date.setDate(date.getDate() - 7);
+  return date;
+};
+
+const EmotionStat = ({ nickname }: EmotionStatProps) => {
+  const [period, _] = useState([calPrevOneWeek(), new Date()]);
+
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['emotionStat', localStorage.getItem('userId')],
+    queryFn: () =>
+      getEmotionStat(
+        Number(localStorage.getItem('userId')),
+        formatDateDash(period[0]),
+        formatDateDash(period[1]),
+      ),
+  });
+
+  if (isLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (isError) {
+    return <p>Error Occurrence!</p>;
+  }
+
+  return (
+    <>
+      <div className="flex w-3/5 items-center justify-between p-5">
+        <h3 className="text-2xl font-bold">최근 {nickname}님의 감정은 어땠을까요?</h3>
+        <div className="flex items-center gap-3">
+          <input
+            className="border-brown rounded-xl border border-solid p-3 outline-none"
+            type="date"
+            defaultValue={formatDateDash(period[0])}
+          />
+          <p>~</p>
+          <input
+            type="date"
+            className="border-brown rounded-xl border border-solid p-3 outline-none"
+            defaultValue={formatDateDash(period[1])}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EmotionStat;

--- a/frontend/src/components/Home/FriendSearchContent.tsx
+++ b/frontend/src/components/Home/FriendSearchContent.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { recommendFriend } from '@api/FriendModal';
 

--- a/frontend/src/components/Home/Grass.tsx
+++ b/frontend/src/components/Home/Grass.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import getGrass from '@api/Grass';
+
 import GrassTooltip from '@components/Home/GrassTooltip';
 
 import { EMOTION_LEVELS } from '@util/constants';

--- a/frontend/src/components/Home/Grass.tsx
+++ b/frontend/src/components/Home/Grass.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import getGrass from '@api/Grass';
 
 import GrassTooltip from '@components/Home/GrassTooltip';

--- a/frontend/src/components/Home/Profile.tsx
+++ b/frontend/src/components/Home/Profile.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-
-import { getCurrentUser } from '@api/Profile';
 
 import Button from '@components/Common/Button';
 import Modal from '@components/Common/Modal';
 import FriendList from '@components/Home/FriendList';
 import FriendRequest from '@components/Home/FriendRequest';
 import ProfileEdit from '@components/Home/ProfileEdit';
+
 import {
   DEFAULT,
   GREET_MESSAGES,
@@ -18,6 +16,7 @@ import {
 
 interface ProfileProps {
   userId: number;
+  userData: ProfileData;
 }
 
 interface ProfileData {
@@ -27,23 +26,11 @@ interface ProfileData {
   isExistedTodayDiary: boolean;
 }
 
-const Profile = ({ userId }: ProfileProps) => {
+const Profile = ({ userId, userData }: ProfileProps) => {
   const [showModalType, setShowModalType] = useState('list');
   const [showModal, setShowModal] = useState(false);
-  const { data, isError, isLoading } = useQuery({
-    queryKey: ['profileData', userId],
-    queryFn: () => getCurrentUser(userId),
-  });
 
-  if (isLoading) {
-    return <p>Loading...</p>;
-  }
-
-  if (isError) {
-    return <p>Error Occurrence!</p>;
-  }
-
-  const { nickname, profileImage, totalFriends, isExistedTodayDiary }: ProfileData = data;
+  const { nickname, profileImage, totalFriends, isExistedTodayDiary }: ProfileData = userData;
 
   const closeModal = () => {
     setShowModal(false);

--- a/frontend/src/components/Home/UserSearchContent.tsx
+++ b/frontend/src/components/Home/UserSearchContent.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { getSearchUserList } from '@api/FriendModal';
 

--- a/frontend/src/components/MyDiary/Calendar.tsx
+++ b/frontend/src/components/MyDiary/Calendar.tsx
@@ -1,41 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
-
-import { getDiaryWeekAndMonthList } from '@api/DiaryList';
-
 import DayItem from '@components/MyDiary/DayItem';
 
-import { DAY_OF_WEEK, NEXT_INDEX, START_INDEX, WEEK_INDEX } from '@util/constants';
-import { formatDateDash } from '@util/funcs';
+import { DAY_OF_WEEK, START_INDEX, WEEK_INDEX } from '@util/constants';
 
 interface CalendarProp {
-  date: Date;
+  first: Date;
+  last: Date;
+  emotionData: { [day: number]: string } | undefined;
 }
 
-const Calendar = ({ date }: CalendarProp) => {
-  const first = new Date(date.getFullYear(), date.getMonth(), 1);
-  const last = new Date(date.getFullYear(), date.getMonth() + NEXT_INDEX, 0);
+const Calendar = ({ first, last, emotionData }: CalendarProp) => {
   const allDayCount = Math.ceil((last.getDate() - first.getDate() + first.getDay()) / WEEK_INDEX);
   const monthData = Array.from(Array(allDayCount), () => Array(WEEK_INDEX).fill(0));
   let day = 1;
-
-  const { isError, isLoading } = useQuery({
-    queryKey: ['monthDiaryData', localStorage.getItem('userId')],
-    queryFn: () =>
-      getDiaryWeekAndMonthList({
-        userId: localStorage.getItem('userId') as string,
-        type: 'Month',
-        startDate: formatDateDash(first),
-        endDate: formatDateDash(last),
-      }),
-  });
-
-  if (isLoading) {
-    return <p>Loading...</p>;
-  }
-
-  if (isError) {
-    return <p>Error Occurrence!</p>;
-  }
 
   for (let weekIndex = START_INDEX; weekIndex < allDayCount; weekIndex++) {
     for (let dayIndex = START_INDEX; dayIndex < WEEK_INDEX; dayIndex++) {
@@ -69,7 +45,10 @@ const Calendar = ({ date }: CalendarProp) => {
                 key={weekIndex + dayIndex}
                 className="border-brown first:text-red last:text-blue border border-solid"
               >
-                <DayItem day={day} emotion={day ? '💜' : undefined} />
+                <DayItem
+                  day={day}
+                  emotion={emotionData && emotionData[day] ? emotionData[day] : undefined}
+                />
               </td>
             ))}
           </tr>

--- a/frontend/src/components/MyDiary/Calendar.tsx
+++ b/frontend/src/components/MyDiary/Calendar.tsx
@@ -18,7 +18,7 @@ const Calendar = ({ date }: CalendarProp) => {
   const monthData = Array.from(Array(allDayCount), () => Array(WEEK_INDEX).fill(0));
   let day = 1;
 
-  const { data, isError, isLoading } = useQuery({
+  const { isError, isLoading } = useQuery({
     queryKey: ['monthDiaryData', localStorage.getItem('userId')],
     queryFn: () =>
       getDiaryWeekAndMonthList({

--- a/frontend/src/components/MyDiary/Calendar.tsx
+++ b/frontend/src/components/MyDiary/Calendar.tsx
@@ -1,6 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getDiaryWeekAndMonthList } from '@api/DiaryList';
+
 import DayItem from '@components/MyDiary/DayItem';
 
 import { DAY_OF_WEEK, NEXT_INDEX, START_INDEX, WEEK_INDEX } from '@util/constants';
+import { formatDateDash } from '@util/funcs';
 
 interface CalendarProp {
   date: Date;
@@ -12,6 +17,25 @@ const Calendar = ({ date }: CalendarProp) => {
   const allDayCount = Math.ceil((last.getDate() - first.getDate() + first.getDay()) / WEEK_INDEX);
   const monthData = Array.from(Array(allDayCount), () => Array(WEEK_INDEX).fill(0));
   let day = 1;
+
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['monthDiaryData', localStorage.getItem('userId')],
+    queryFn: () =>
+      getDiaryWeekAndMonthList({
+        userId: localStorage.getItem('userId') as string,
+        type: 'Month',
+        startDate: formatDateDash(first),
+        endDate: formatDateDash(last),
+      }),
+  });
+
+  if (isLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (isError) {
+    return <p>Error Occurrence!</p>;
+  }
 
   for (let weekIndex = START_INDEX; weekIndex < allDayCount; weekIndex++) {
     for (let dayIndex = START_INDEX; dayIndex < WEEK_INDEX; dayIndex++) {

--- a/frontend/src/components/MyDiary/Card.tsx
+++ b/frontend/src/components/MyDiary/Card.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import EmojiPicker from 'emoji-picker-react';
 
 import { IDiaryContent } from '@type/components/Common/DiaryList';
@@ -10,7 +11,6 @@ import Modal from '@components/Common/Modal';
 
 import { formatDateString } from '@util/funcs';
 import { SMALL } from '@util/constants';
-import { useNavigate } from 'react-router-dom';
 
 interface CardProps {
   data: IDiaryContent;
@@ -43,12 +43,12 @@ const Card = ({ data, styles, size }: CardProps) => {
         <h3 className="text-xl font-bold">{data.title}</h3>
         <img src={data.thumbnail} alt="일기의 대표 이미지" />
         <div className="whitespace-pre-wrap text-sm">
-          <p>{data.content}</p>
+          <p>{data.summary}</p>
         </div>
       </div>
       <div className="flex w-full flex-wrap gap-3">
-        {data.keywords.map((keyword, index) => (
-          <Keyword key={index} text={keyword} styles={`${size === SMALL ? 'text-xs' : ''}`} />
+        {data.tags.map((tag, index) => (
+          <Keyword key={index} text={tag} styles={`${size === SMALL ? 'text-xs' : ''}`} />
         ))}
       </div>
       <Reaction

--- a/frontend/src/components/MyDiary/Card.tsx
+++ b/frontend/src/components/MyDiary/Card.tsx
@@ -10,6 +10,7 @@ import Modal from '@components/Common/Modal';
 
 import { formatDateString } from '@util/funcs';
 import { SMALL } from '@util/constants';
+import { useNavigate } from 'react-router-dom';
 
 interface CardProps {
   data: IDiaryContent;
@@ -18,6 +19,8 @@ interface CardProps {
 }
 
 const Card = ({ data, styles, size }: CardProps) => {
+  const navigate = useNavigate();
+
   const [showModal, setShowModal] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [selectedEmoji, setSelectedEmoji] = useState('');
@@ -25,6 +28,7 @@ const Card = ({ data, styles, size }: CardProps) => {
   const toggleShowModal = () => setShowModal((prev) => !prev);
   const toggleShowEmojiPicker = () => setShowEmojiPicker((prev) => !prev);
 
+  const goDetail = () => navigate(`/detail/${data.diaryId}`);
   const onClickEmoji = (emojiData: any) => {
     setSelectedEmoji(emojiData.emoji);
     toggleShowEmojiPicker();
@@ -34,18 +38,19 @@ const Card = ({ data, styles, size }: CardProps) => {
     <div
       className={`border-brown relative flex flex-col gap-3 rounded-xl border border-solid px-7 py-6 ${styles}`}
     >
-      <p className={`${size === SMALL ? 'text-sm' : ''}`}>{formatDateString(data.createdAt)}</p>
-      <h3 className="text-xl font-bold">{data.title}</h3>
-      <img src={data.thumbnail} alt="일기의 대표 이미지" />
-      <div className="whitespace-pre-wrap text-sm">
-        <p>{data.content}</p>
+      <div onClick={goDetail} className="flex cursor-pointer flex-col gap-3">
+        <p className={`${size === SMALL ? 'text-sm' : ''}`}>{formatDateString(data.createdAt)}</p>
+        <h3 className="text-xl font-bold">{data.title}</h3>
+        <img src={data.thumbnail} alt="일기의 대표 이미지" />
+        <div className="whitespace-pre-wrap text-sm">
+          <p>{data.content}</p>
+        </div>
       </div>
       <div className="flex w-full flex-wrap gap-3">
         {data.keywords.map((keyword, index) => (
           <Keyword key={index} text={keyword} styles={`${size === SMALL ? 'text-xs' : ''}`} />
         ))}
       </div>
-
       <Reaction
         count={data.reactionCount}
         textOnClick={toggleShowModal}

--- a/frontend/src/components/MyDiary/CarouselContainer.tsx
+++ b/frontend/src/components/MyDiary/CarouselContainer.tsx
@@ -16,8 +16,6 @@ const CarouselContainer = ({ data }: CarouselContainerProps) => {
   const dataLength = data.length;
   const prevIndex =
     activeIndex === 0 ? activeIndex + PREV_INDEX + dataLength : activeIndex + PREV_INDEX;
-  console.log('data 전부', data);
-  console.log('dataLength', dataLength, 'prevIndex!!', prevIndex);
 
   return (
     <section className="flex w-fit items-center justify-center">

--- a/frontend/src/components/MyDiary/CarouselContainer.tsx
+++ b/frontend/src/components/MyDiary/CarouselContainer.tsx
@@ -7,11 +7,17 @@ import Card from '@components/MyDiary/Card';
 
 import { PREV_INDEX, LARGE, NEXT_INDEX, SMALL } from '@util/constants';
 
-const CarouselContainer = (data: IDiaryContent[]) => {
+interface CarouselContainerProps {
+  data: IDiaryContent[];
+}
+
+const CarouselContainer = ({ data }: CarouselContainerProps) => {
   const [activeIndex, setActiveIndex] = useState(0);
   const dataLength = data.length;
   const prevIndex =
     activeIndex === 0 ? activeIndex + PREV_INDEX + dataLength : activeIndex + PREV_INDEX;
+  console.log('data 전부', data);
+  console.log('dataLength', dataLength, 'prevIndex!!', prevIndex);
 
   return (
     <section className="flex w-fit items-center justify-center">

--- a/frontend/src/components/MyDiary/DayItem.tsx
+++ b/frontend/src/components/MyDiary/DayItem.tsx
@@ -5,7 +5,7 @@ interface DayItemProps {
 
 const DayItem = ({ day, emotion }: DayItemProps) => {
   return (
-    <div className="flex flex-col p-3">
+    <div className="flex h-24 flex-col p-3">
       {day > 0 && (
         <>
           <p className="text-xs">{String(day).padStart(2, '0')}</p>

--- a/frontend/src/components/MyDiary/MonthContainer.tsx
+++ b/frontend/src/components/MyDiary/MonthContainer.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { getDiaryWeekAndMonthList } from '@api/DiaryList';
+
+import { IDiaryContent } from '@type/components/Common/DiaryList';
+
+import DateController from '@components/MyDiary/DateController';
+import Calendar from '@components/MyDiary/Calendar';
+
+import { NEXT_INDEX } from '@util/constants';
+import { formatDateDash, getNowMonth } from '@util/funcs';
+
+const MonthContainer = () => {
+  const [nowMonth, setNowMonth] = useState(new Date());
+  const first = new Date(nowMonth.getFullYear(), nowMonth.getMonth(), 1);
+  const last = new Date(nowMonth.getFullYear(), nowMonth.getMonth() + NEXT_INDEX, 0);
+
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['monthDiaryData', localStorage.getItem('userId'), nowMonth],
+    queryFn: () =>
+      getDiaryWeekAndMonthList({
+        userId: localStorage.getItem('userId') as string,
+        type: 'Month',
+        startDate: formatDateDash(first),
+        endDate: formatDateDash(last),
+      }),
+    select: (data) => {
+      const emotionObject: { [day: number]: string } = {};
+      data.diaryList.forEach((diary: IDiaryContent) => {
+        const { emotion, createdAt } = diary;
+        const day = new Date(createdAt).getDate();
+        emotionObject[day] = emotion;
+      });
+      return emotionObject;
+    },
+  });
+
+  if (isLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (isError) {
+    return <p>Error Occurrence!</p>;
+  }
+
+  const setPrevOrNextMonth = (plus: number) => {
+    const month = new Date(nowMonth);
+    month.setMonth(month.getMonth() + plus);
+    setNowMonth(month);
+  };
+
+  return (
+    <>
+      <DateController
+        titles={[getNowMonth(nowMonth).join(' '), String(nowMonth.getFullYear())]}
+        leftOnClick={() => setPrevOrNextMonth(-1)}
+        rightOnClick={() => setPrevOrNextMonth(1)}
+      />
+      <Calendar first={first} last={last} emotionData={data} />
+    </>
+  );
+};
+
+export default MonthContainer;

--- a/frontend/src/components/MyDiary/WeekContainer.tsx
+++ b/frontend/src/components/MyDiary/WeekContainer.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { getDiaryWeekAndMonthList } from '@api/DiaryList';
+
+import { IDiaryContent } from '@type/components/Common/DiaryList';
+
+import Card from '@components/MyDiary/Card';
+import CarouselContainer from '@components/MyDiary/CarouselContainer';
+import DateController from '@components/MyDiary/DateController';
+
+import { WEEK_STANDARD_LENGTH } from '@util/constants';
+import { getNowWeek, formatDate, formatDateDash } from '@util/funcs';
+
+const calPeriod = () => {
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - startDate.getDay());
+  const endDate = new Date();
+  endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
+  return [startDate, endDate];
+};
+
+const WeekContainer = () => {
+  const [nowWeek, setNowWeek] = useState(getNowWeek(new Date()));
+  const [period, setPeriod] = useState(calPeriod());
+
+  const { data } = useQuery<{ nickname: string; diaryList: IDiaryContent[] }>({
+    queryKey: ['myWeekDiary', localStorage.getItem('userId'), period[0], period[1]],
+    queryFn: () =>
+      getDiaryWeekAndMonthList({
+        userId: localStorage.getItem('userId') as string,
+        type: 'Week',
+        startDate: formatDateDash(period[0]),
+        endDate: formatDateDash(period[1]),
+      }),
+  });
+
+  console.log('data', data);
+
+  const setPrevOrNextWeek = (plus: number) => {
+    setPeriod(changePeriod(plus));
+    setNowWeek(getNowWeek(period[1]));
+  };
+
+  const changePeriod = (plus: number) => {
+    const [startDate, endDate] = period;
+    startDate.setDate(startDate.getDate() + plus * 7);
+    endDate.setDate(endDate.getDate() + plus * 7);
+    return [startDate, endDate];
+  };
+
+  return (
+    <>
+      <DateController
+        titles={[
+          `Week ${String(nowWeek).padStart(2, '0')}`,
+          `${formatDate(period[0])} ~ ${formatDate(period[1])}`,
+        ]}
+        leftOnClick={() => setPrevOrNextWeek(-1)}
+        rightOnClick={() => setPrevOrNextWeek(1)}
+      />
+      {data && data.diaryList.length < WEEK_STANDARD_LENGTH && (
+        <section className="flex gap-5">
+          {data.diaryList.map((diaryItem, index) => (
+            <Card data={diaryItem} key={index} />
+          ))}
+        </section>
+      )}
+      {data && data.diaryList.length >= WEEK_STANDARD_LENGTH && (
+        <CarouselContainer data={data.diaryList} />
+      )}
+    </>
+  );
+};
+
+export default WeekContainer;

--- a/frontend/src/components/MyDiary/WeekContainer.tsx
+++ b/frontend/src/components/MyDiary/WeekContainer.tsx
@@ -35,8 +35,6 @@ const WeekContainer = () => {
       }),
   });
 
-  console.log('data', data);
-
   const setPrevOrNextWeek = (plus: number) => {
     setPeriod(changePeriod(plus));
     setNowWeek(getNowWeek(period[1]));

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -14,7 +14,7 @@ const Feed = () => {
         'https://mblogthumb-phinf.pstatic.net/MjAyMzA1MDZfMjg2/MDAxNjgzMzY5MzE1MTky.eVMofWydN_T-5Cn227nrfcdyPVzpHRN2jaJXGLeVyUUg.S_l9nnV4ANRX4t9isjrt5rbUd8iWyM8D8w6yJMcPktEg.PNG.withwithpet/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7_2023-05-06_%EC%98%A4%ED%9B%84_7.25.06.png?type=w800',
       title: '시고르자브종',
       content: `일기내용입니다.\n일기내용입니다.\n세 번째 줄까지만 보입니다다다다다다다다다다다다다다다다다다다다\n4줄부터 안보입니다!!\n`,
-      keywords: ['키워드1', '키워드2', '키워드3', '키워드4'],
+      tags: ['키워드1', '키워드2', '키워드3', '키워드4'],
       reactionCount: 10,
       diaryId: 1,
       authorId: 1,

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -18,6 +18,7 @@ const Feed = () => {
       reactionCount: 10,
       diaryId: 1,
       authorId: 1,
+      emotion: '😀',
     },
   ];
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -15,13 +15,9 @@ const Home = () => {
   const params = useParams();
   const userId = params.userId ? params.userId : localStorage.getItem('userId');
 
-  if (!userId) {
-    return alert('로그인하세요');
-  }
-
   const { data, isError, isLoading } = useQuery({
     queryKey: ['profileData', userId],
-    queryFn: () => getCurrentUser(+userId),
+    queryFn: () => getCurrentUser(userId ? +userId : 0),
   });
 
   if (isLoading) {
@@ -37,7 +33,7 @@ const Home = () => {
   return (
     <main className="mb-28 flex flex-col items-center justify-start">
       <NavBar />
-      <Profile userId={+userId} userData={data} />
+      <Profile userId={userId ? +userId : 0} userData={data} />
       <Grass />
       <EmotionStat nickname={data.nickname} />
       <DiaryList pageType={HOME} diaryData={DUMMY_DATA} />

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,9 +1,13 @@
 import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import { getCurrentUser } from '@api/Profile';
 
 import DiaryList from '@components/Common/DiaryList';
 import NavBar from '@components/Common/NavBar';
 import Profile from '@components/Home/Profile';
 import Grass from '@components/Home/Grass';
+import EmotionStat from '@components/Home/EmotionStat';
 
 import { DUMMY_DATA, HOME } from '@util/constants';
 
@@ -11,13 +15,31 @@ const Home = () => {
   const params = useParams();
   const userId = params.userId ? params.userId : localStorage.getItem('userId');
 
+  if (!userId) {
+    return alert('로그인하세요');
+  }
+
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['profileData', userId],
+    queryFn: () => getCurrentUser(+userId),
+  });
+
+  if (isLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (isError) {
+    return <p>Error Occurrence!</p>;
+  }
+
   // TODO: 무한스크롤 => 데이터 빈 객체로 오는 것 백엔드와 함께 해결
 
   return (
     <main className="mb-28 flex flex-col items-center justify-start">
       <NavBar />
-      <Profile userId={Number(userId)} />
+      <Profile userId={+userId} userData={data} />
       <Grass />
+      <EmotionStat nickname={data.nickname} />
       <DiaryList pageType={HOME} diaryData={DUMMY_DATA} />
     </main>
   );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,23 +1,54 @@
 import { useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { getCurrentUser } from '@api/Profile';
+import { getDiaryDayList } from '@api/DiaryList';
 
-import DiaryList from '@components/Common/DiaryList';
+import { InfiniteDiaryListProps } from '@type/components/Common/DiaryList';
+
 import NavBar from '@components/Common/NavBar';
+import DiaryList from '@components/Common/DiaryList';
 import Profile from '@components/Home/Profile';
 import Grass from '@components/Home/Grass';
 import EmotionStat from '@components/Home/EmotionStat';
 
-import { DUMMY_DATA, HOME } from '@util/constants';
+import { HOME } from '@util/constants';
 
 const Home = () => {
   const params = useParams();
   const userId = params.userId ? params.userId : localStorage.getItem('userId');
 
-  const { data, isError, isLoading } = useQuery({
+  const {
+    data: profileData,
+    isError,
+    isLoading,
+  } = useQuery({
     queryKey: ['profileData', userId],
     queryFn: () => getCurrentUser(userId ? +userId : 0),
+  });
+
+  const { data: diaryData } = useInfiniteQuery<
+    any,
+    Error,
+    InfiniteDiaryListProps,
+    [string, string | null]
+  >({
+    queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+    queryFn: getDiaryDayList,
+    initialPageParam: {
+      userId: localStorage.getItem('userId') as string,
+      type: 'Day',
+      lastIndex: 2e9,
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage && lastPage.diaryList.length >= 5
+        ? {
+            userId: localStorage.getItem('userId') as string,
+            type: 'Day',
+            lastIndex: lastPage?.diaryList.at(-1).diaryId,
+          }
+        : undefined;
+    },
   });
 
   if (isLoading) {
@@ -33,10 +64,17 @@ const Home = () => {
   return (
     <main className="mb-28 flex flex-col items-center justify-start">
       <NavBar />
-      <Profile userId={userId ? +userId : 0} userData={data} />
+      <Profile userId={userId ? +userId : 0} userData={profileData} />
       <Grass />
-      <EmotionStat nickname={data.nickname} />
-      <DiaryList pageType={HOME} diaryData={DUMMY_DATA} />
+      <EmotionStat nickname={profileData.nickname} />
+      {diaryData?.pages.map((page, index) => (
+        <DiaryList
+          key={index}
+          pageType={HOME}
+          diaryData={page.diaryList}
+          username={page.nickname}
+        />
+      ))}
     </main>
   );
 };

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,14 +1,18 @@
+import { useParams } from 'react-router-dom';
+
 import DiaryList from '@components/Common/DiaryList';
 import NavBar from '@components/Common/NavBar';
 import Profile from '@components/Home/Profile';
 import Grass from '@components/Home/Grass';
 
 import { DUMMY_DATA, HOME } from '@util/constants';
-import { useParams } from 'react-router-dom';
 
 const Home = () => {
   const params = useParams();
   const userId = params.userId ? params.userId : localStorage.getItem('userId');
+
+  // TODO: 무한스크롤 => 데이터 빈 객체로 오는 것 백엔드와 함께 해결
+
   return (
     <main className="mb-28 flex flex-col items-center justify-start">
       <NavBar />

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -15,8 +15,7 @@ import Calendar from '@components/MyDiary/Calendar';
 import Card from '@components/MyDiary/Card';
 import CarouselContainer from '@components/MyDiary/CarouselContainer';
 
-import { formatDateDash, getNowMonth, getNowWeek } from '@util/funcs';
-import { formatDate } from '@util/funcs';
+import { formatDate, formatDateDash, getNowMonth, getNowWeek } from '@util/funcs';
 import { DIARY_VIEW_TYPE, DUMMY_DATA, WEEK_STANDARD_LENGTH } from '@util/constants';
 
 const calPeriod = () => {

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -1,74 +1,41 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { getDiaryWeekAndMonthList } from '@api/DiaryList';
+import { getDiaryDayList } from '@api/DiaryList';
 
 import { viewTypes } from '@type/pages/MyDiary';
-import { IDiaryContent } from '@type/components/Common/DiaryList';
+import { InfiniteDiaryListProps } from '@type/components/Common/DiaryList';
 
 import NavBar from '@components/Common/NavBar';
-import KeywordSearch from '@components/MyDiary/KeywordSearch';
-import ViewType from '@components/MyDiary/ViewType';
 import DiaryListItem from '@components/Common/DiaryListItem';
-import DateController from '@components/MyDiary/DateController';
-import Calendar from '@components/MyDiary/Calendar';
-import Card from '@components/MyDiary/Card';
-import CarouselContainer from '@components/MyDiary/CarouselContainer';
+import KeywordSearch from '@components/MyDiary/KeywordSearch';
+import WeekContainer from '@components/MyDiary/WeekContainer';
+import ViewType from '@components/MyDiary/ViewType';
+import MonthContainer from '@components/MyDiary/MonthContainer';
 
-import { formatDate, formatDateDash, getNowMonth, getNowWeek } from '@util/funcs';
-import { DIARY_VIEW_TYPE, DUMMY_DATA, WEEK_STANDARD_LENGTH } from '@util/constants';
-
-const calPeriod = () => {
-  const startDate = new Date();
-  startDate.setDate(startDate.getDate() - startDate.getDay());
-  const endDate = new Date();
-  endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
-  return [startDate, endDate];
-};
+import { DIARY_VIEW_TYPE } from '@util/constants';
 
 const MyDiary = () => {
   const [viewType, setViewType] = useState<viewTypes>('Day');
-  const [diaryData, _] = useState<IDiaryContent[]>(DUMMY_DATA);
-  const [nowMonth, setNowMonth] = useState(new Date());
-  const [nowWeek, setNowWeek] = useState(getNowWeek(new Date()));
-  const [period, setPeriod] = useState(calPeriod());
 
-  const { data, isError, isLoading } = useQuery<{ nickname: string; diaryList: IDiaryContent[] }>({
-    queryKey: ['myWeekDiary', localStorage.getItem('userId')],
-    queryFn: () =>
-      getDiaryWeekAndMonthList({
-        userId: localStorage.getItem('userId') as string,
-        type: 'Week',
-        startDate: formatDateDash(period[0]),
-        endDate: formatDateDash(period[1]),
-      }),
+  const { data } = useInfiniteQuery<any, Error, InfiniteDiaryListProps, [string, string | null]>({
+    queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+    queryFn: getDiaryDayList,
+    initialPageParam: {
+      userId: localStorage.getItem('userId') as string,
+      type: 'Day',
+      lastIndex: 2e9,
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage && lastPage.diaryList.length >= 5
+        ? {
+            userId: localStorage.getItem('userId') as string,
+            type: 'Day',
+            lastIndex: lastPage?.diaryList.at(-1).diaryId,
+          }
+        : undefined;
+    },
   });
-
-  if (isLoading) {
-    return <p>Loading...</p>;
-  }
-
-  if (isError) {
-    return <p>Error Occurrence!</p>;
-  }
-
-  const setPrevOrNextMonth = (plus: number) => {
-    const month = new Date(nowMonth);
-    month.setMonth(month.getMonth() + plus);
-    setNowMonth(month);
-  };
-
-  const setPrevOrNextWeek = (plus: number) => {
-    setPeriod(changePeriod(plus));
-    setNowWeek(getNowWeek(period[1]));
-  };
-
-  const changePeriod = (plus: number) => {
-    const [startDate, endDate] = period;
-    startDate.setDate(startDate.getDate() + plus * 7);
-    endDate.setDate(endDate.getDate() + plus * 7);
-    return [startDate, endDate];
-  };
 
   return (
     <>
@@ -80,39 +47,11 @@ const MyDiary = () => {
         </header>
         <section className="flex flex-col items-center">
           {viewType === DIARY_VIEW_TYPE.DAY &&
-            diaryData.map((data, index) => <DiaryListItem diaryItem={data} key={index} />)}
-          {viewType === DIARY_VIEW_TYPE.WEEK && (
-            <>
-              <DateController
-                titles={[
-                  `Week ${String(nowWeek).padStart(2, '0')}`,
-                  `${formatDate(period[0])} ~ ${formatDate(period[1])}`,
-                ]}
-                leftOnClick={() => setPrevOrNextWeek(-1)}
-                rightOnClick={() => setPrevOrNextWeek(1)}
-              />
-              {data && data.diaryList.length < WEEK_STANDARD_LENGTH && (
-                <section className="flex gap-5">
-                  {data.diaryList.map((diaryItem, index) => (
-                    <Card data={diaryItem} key={index} />
-                  ))}
-                </section>
-              )}
-              {data && data.diaryList.length >= WEEK_STANDARD_LENGTH && (
-                <CarouselContainer data={data.diaryList} />
-              )}
-            </>
-          )}
-          {viewType === DIARY_VIEW_TYPE.MONTH && (
-            <>
-              <DateController
-                titles={[getNowMonth(nowMonth).join(' '), String(nowMonth.getFullYear())]}
-                leftOnClick={() => setPrevOrNextMonth(-1)}
-                rightOnClick={() => setPrevOrNextMonth(1)}
-              />
-              <Calendar date={nowMonth} />
-            </>
-          )}
+            data?.pages.map((page) =>
+              page.diaryList.map((item, index) => <DiaryListItem key={index} diaryItem={item} />),
+            )}
+          {viewType === DIARY_VIEW_TYPE.WEEK && <WeekContainer />}
+          {viewType === DIARY_VIEW_TYPE.MONTH && <MonthContainer />}
         </section>
       </main>
     </>

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { viewTypes } from '@type/pages/MyDiary';
 import { IDiaryContent } from '@type/components/Common/DiaryList';
@@ -26,7 +26,7 @@ const calPeriod = () => {
 
 const MyDiary = () => {
   const [viewType, setViewType] = useState<viewTypes>('Day');
-  const [diaryData, setDiaryData] = useState<IDiaryContent[]>(DUMMY_DATA);
+  const [diaryData, _] = useState<IDiaryContent[]>(DUMMY_DATA);
   const [nowMonth, setNowMonth] = useState(new Date());
   const [nowWeek, setNowWeek] = useState(getNowWeek(new Date()));
   const [period, setPeriod] = useState(calPeriod());
@@ -49,9 +49,7 @@ const MyDiary = () => {
     return [startDate, endDate];
   };
 
-  useEffect(() => {
-    setDiaryData(DUMMY_DATA);
-  }, []);
+  console.log('diaryData', diaryData);
 
   return (
     <>
@@ -74,14 +72,14 @@ const MyDiary = () => {
                 leftOnClick={() => setPrevOrNextWeek(-1)}
                 rightOnClick={() => setPrevOrNextWeek(1)}
               />
-              {DUMMY_DATA.length < WEEK_STANDARD_LENGTH && (
+              {diaryData.length < WEEK_STANDARD_LENGTH && (
                 <section className="flex gap-5">
-                  {DUMMY_DATA.map((data) => (
-                    <Card data={data} />
+                  {diaryData.map((data, index) => (
+                    <Card data={data} key={index} />
                   ))}
                 </section>
               )}
-              {DUMMY_DATA.length >= WEEK_STANDARD_LENGTH && <CarouselContainer {...DUMMY_DATA} />}
+              {diaryData.length >= WEEK_STANDARD_LENGTH && <CarouselContainer data={diaryData} />}
             </>
           )}
           {viewType === DIARY_VIEW_TYPE.MONTH && (

--- a/frontend/src/types/components/Common/DiaryList.ts
+++ b/frontend/src/types/components/Common/DiaryList.ts
@@ -4,8 +4,9 @@ export interface IDiaryContent {
   nickname: string;
   thumbnail?: string;
   title: string;
-  content: string;
-  keywords: string[];
+  content?: string;
+  summary?: string;
+  tags: string[];
   reactionCount: number;
   authorId: string | number;
   diaryId: string | number;

--- a/frontend/src/types/components/Common/DiaryList.ts
+++ b/frontend/src/types/components/Common/DiaryList.ts
@@ -1,13 +1,28 @@
+import { viewTypes } from '@type/pages/MyDiary';
+
 export interface IDiaryContent {
   createdAt: string;
-  profileImage: string;
-  nickname: string;
+  profileImage?: string;
+  nickname?: string;
   thumbnail?: string;
   title: string;
   content?: string;
   summary?: string;
   tags: string[];
+  emotion: string;
   reactionCount: number;
-  authorId: string | number;
+  authorId?: string | number;
   diaryId: string | number;
+}
+
+export interface InfiniteDiaryListProps {
+  pages: {
+    nickname: string;
+    diaryList: IDiaryContent[];
+  }[];
+  pageParams: {
+    userId: string;
+    type: viewTypes;
+    lastIndex: number;
+  }[];
 }

--- a/frontend/src/types/components/Home/Profile.ts
+++ b/frontend/src/types/components/Home/Profile.ts
@@ -1,0 +1,6 @@
+export interface ProfileData {
+  nickname: string;
+  profileImage: string;
+  totalFriends: number;
+  isExistedTodayDiary: boolean;
+}

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,6 +1,6 @@
 // TODO: PR 올릴 때 SERVER URL 배포 URL로 되어 있는지 확인
-// const SERVER_URL = 'http://223.130.146.253:3000';
-const SERVER_URL = 'http://localhost:3000';
+const SERVER_URL = 'http://223.130.146.253:3000';
+// const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';
 const USER = '/users';

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,5 +1,5 @@
 // TODO: PR 올릴 때 SERVER URL 배포 URL로 되어 있는지 확인
-const SERVER_URL = 'http://223.130.146.253:3000';
+const SERVER_URL = 'https://223.130.146.253:3001';
 // const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,6 +1,6 @@
 // TODO: PR 올릴 때 SERVER URL 배포 URL로 되어 있는지 확인
-const SERVER_URL = 'http://223.130.146.253:3000';
-// const SERVER_URL = 'http://localhost:3000';
+// const SERVER_URL = 'http://223.130.146.253:3000';
+const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';
 const USER = '/users';
@@ -28,8 +28,8 @@ const API_PATH = {
     keywordSearch: (keyword: string) => SERVER_URL + DIARY + TAG + `/${keyword}`,
     feed: (lastIndex: number) => SERVER_URL + DIARY + `/friends?lastIndex=${lastIndex}`,
     grass: (id: number) => SERVER_URL + DIARY + '/mood' + `/${id}`,
-    emotion: (id: number, startDate: number, lastDate: number) =>
-      SERVER_URL + DIARY + '/emotion' + `/${id}` + `?startDate=${startDate}&lastDate=${lastDate}`,
+    emotion: (id: number, startDate: string, lastDate: string) =>
+      SERVER_URL + DIARY + '/emotions' + `/${id}` + `?startDate=${startDate}&lastDate=${lastDate}`,
     myDiaryDay: (id: string, type: string, lastIndex?: number) =>
       SERVER_URL + DIARY + USER + `/${id}?type=${type}&lastIndex=${lastIndex}`,
     myDiaryWeekAndMonth: (id: string, type: string, startDate: string, endDate: string) =>

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,5 +1,6 @@
-const SERVER_URL = 'http://223.130.146.253:3000';
-// const SERVER_URL = 'http://localhost:3000';
+// TODO: PR 올릴 때 SERVER URL 배포 URL로 되어 있는지 확인
+// const SERVER_URL = 'http://223.130.146.253:3000';
+const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';
 const USER = '/users';
@@ -29,11 +30,26 @@ const API_PATH = {
     grass: (id: number) => SERVER_URL + DIARY + '/mood' + `/${id}`,
     emotion: (id: number, startDate: number, lastDate: number) =>
       SERVER_URL + DIARY + '/emotion' + `/${id}` + `?startDate=${startDate}&lastDate=${lastDate}`,
-    myDiary: (id: number, type: string, startDate: number, endDate: number, lastIndex: number) =>
-      SERVER_URL +
-      DIARY +
-      USER +
-      `${id}?type=${type}&startDate=${startDate}&endDate=${endDate}&lastIndex=${lastIndex}`,
+    myDiary: (
+      id: number,
+      type: string,
+      lastIndex?: number,
+      startDate?: string,
+      endDate?: string,
+    ) => {
+      switch (type) {
+        case 'Day':
+          return SERVER_URL + DIARY + USER + `${id}?type=${type}&lastIndex=${lastIndex}`;
+        default:
+          return (
+            SERVER_URL +
+            DIARY +
+            USER +
+            `${id}?type=${type}&startDate=${startDate}&endDate=${endDate}`
+          );
+      }
+    },
+
     create: () => SERVER_URL + DIARY,
   },
   REACTION: {

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,6 +1,6 @@
 // TODO: PR 올릴 때 SERVER URL 배포 URL로 되어 있는지 확인
-// const SERVER_URL = 'http://223.130.146.253:3000';
-const SERVER_URL = 'http://localhost:3000';
+const SERVER_URL = 'http://223.130.146.253:3000';
+// const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';
 const USER = '/users';
@@ -30,26 +30,10 @@ const API_PATH = {
     grass: (id: number) => SERVER_URL + DIARY + '/mood' + `/${id}`,
     emotion: (id: number, startDate: number, lastDate: number) =>
       SERVER_URL + DIARY + '/emotion' + `/${id}` + `?startDate=${startDate}&lastDate=${lastDate}`,
-    myDiary: (
-      id: number,
-      type: string,
-      lastIndex?: number,
-      startDate?: string,
-      endDate?: string,
-    ) => {
-      switch (type) {
-        case 'Day':
-          return SERVER_URL + DIARY + USER + `${id}?type=${type}&lastIndex=${lastIndex}`;
-        default:
-          return (
-            SERVER_URL +
-            DIARY +
-            USER +
-            `${id}?type=${type}&startDate=${startDate}&endDate=${endDate}`
-          );
-      }
-    },
-
+    myDiaryDay: (id: string, type: string, lastIndex?: number) =>
+      SERVER_URL + DIARY + USER + `/${id}?type=${type}&lastIndex=${lastIndex}`,
+    myDiaryWeekAndMonth: (id: string, type: string, startDate: string, endDate: string) =>
+      SERVER_URL + DIARY + USER + `/${id}?type=${type}&startDate=${startDate}&endDate=${endDate}`,
     create: () => SERVER_URL + DIARY,
   },
   REACTION: {

--- a/frontend/src/util/constants.ts
+++ b/frontend/src/util/constants.ts
@@ -15,6 +15,7 @@ export const DUMMY_DATA = [
     reactionCount: 1000,
     authorId: 1,
     diaryId: 1,
+    emotion: '😀',
   },
   {
     createdAt: '2023-11-13T13:50:17.106Z',
@@ -29,6 +30,7 @@ export const DUMMY_DATA = [
     reactionCount: 10,
     authorId: 1,
     diaryId: 1,
+    emotion: '😀',
   },
   {
     createdAt: '2023-11-13T13:50:17.106Z',
@@ -43,6 +45,7 @@ export const DUMMY_DATA = [
     reactionCount: 10,
     authorId: 1,
     diaryId: 1,
+    emotion: '😀',
   },
 ];
 

--- a/frontend/src/util/constants.ts
+++ b/frontend/src/util/constants.ts
@@ -11,7 +11,7 @@ export const DUMMY_DATA = [
       'https://cdn.inflearn.com/public/files/pages/38c3fb10-72a4-4ea5-8361-4ee6b682e188/SVG.jpg',
     title: '첫번째',
     content: `일기내용입니다.\n일기내용입니다.\n세 번째 줄까지만 보입니다다다다다다다다다다다다다다다다다다다다`,
-    keywords: ['키워드1', '키워드2', '키워드3', '키워드4'],
+    tags: ['키워드1', '키워드2', '키워드3', '키워드4'],
     reactionCount: 1000,
     authorId: 1,
     diaryId: 1,
@@ -25,7 +25,7 @@ export const DUMMY_DATA = [
     title: '두번째',
     content:
       '일기내용입니다.\n일기내용입니다.\n세 번째 줄까지만 보입니다다다다다다다다다다다다다다다다다다다다',
-    keywords: ['키워드1', '키워드2', '키워드3', '키워드4'],
+    tags: ['키워드1', '키워드2', '키워드3', '키워드4'],
     reactionCount: 10,
     authorId: 1,
     diaryId: 1,
@@ -39,7 +39,7 @@ export const DUMMY_DATA = [
     title: '마지막',
     content:
       '일기내용입니다.\n일기내용입니다.\n세 번째 줄까지만 보입니다다다다다다다다다다다다다다다다다다다다',
-    keywords: ['키워드1', '키워드2', '키워드3', '키워드4'],
+    tags: ['키워드1', '키워드2', '키워드3', '키워드4'],
     reactionCount: 10,
     authorId: 1,
     diaryId: 1,

--- a/frontend/src/util/funcs.ts
+++ b/frontend/src/util/funcs.ts
@@ -27,3 +27,11 @@ export const formatDateString = (str: string) => {
 
   return `${year}년 ${month}월 ${day}일 ${DAY_OF_WEEK[date]}`;
 };
+
+export const formatDateDash = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};

--- a/frontend/src/util/funcs.ts
+++ b/frontend/src/util/funcs.ts
@@ -1,4 +1,4 @@
-import { DAY_OF_WEEK } from './constants';
+import { DAY_OF_WEEK } from '@util/constants';
 
 export const getNowMonth = (date: Date) => {
   const month = date.getMonth() + 1;


### PR DESCRIPTION
## 이슈 번호
#157, #158, #184

## 완료한 기능 명세
<img width="816" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/c9852d7a-eccd-4ed1-b1b6-45ef7af9872f">
<img width="730" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/cd694663-8ef2-4624-85fd-a91d9cd4a896">

- 내가 작성한 일기 API 연동 마무리
  - useInfiniteQuery를 활용한 API 연동
- my-diary 페이지 로직 수정
  - 뷰타입 클릭 시 각 뷰타입에 맞는 API 요청하도록 WeekContainer와 MonthContainer 컴포넌트 분리
- 감정 통계 API 연동
- Week undefined 에러 해결
- Card 컴포넌트 클릭 시 일기 디테일로 이동 추가

-----

하다 보니 PR 하나에 담긴 작업의 양이 너무 많네요 🥹 다음 PR은 더 잘게 쪼개보겠습니다!!
