### PR TITLE
[FE] 검색 API 연동 완료, 피드 API 연동 중

### DIFF
--- a/frontend/src/components/MyDiary/Calendar.tsx
+++ b/frontend/src/components/MyDiary/Calendar.tsx
@@ -49,8 +49,8 @@ const Calendar = ({ first, last, emotionData }: CalendarProp) => {
               >
                 <DayItem
                   day={day}
-                  diaryId={emotionData && emotionData[day] ? emotionData[day].diaryId : undefined}
-                  emotion={emotionData && emotionData[day] ? emotionData[day].emotion : undefined}
+                  diaryId={emotionData?.[day]?.diaryId}
+                  emotion={emotionData?.[day]?.emotion}
                 />
               </td>
             ))}

--- a/frontend/src/components/MyDiary/KeywordSearch.tsx
+++ b/frontend/src/components/MyDiary/KeywordSearch.tsx
@@ -5,6 +5,7 @@ import { getTagRecommend } from '@api/KeywordSearch';
 import { searchOptionsType } from '@type/pages/MyDiary';
 
 import Icon from '@components/Common/Icon';
+import { DEBOUNCE_TIME } from '@/util/constants';
 
 interface KeywordSearchProps {
   keyword: string;
@@ -31,7 +32,7 @@ const KeywordSearch = ({
         const data = await getTagRecommend(keyword);
         setRecommendKeyword(data.keywords);
       }
-    }, 1000);
+    }, DEBOUNCE_TIME);
     return () => clearTimeout(timer);
   }, [keyword]);
 

--- a/frontend/src/util/constants.ts
+++ b/frontend/src/util/constants.ts
@@ -107,3 +107,5 @@ export const NAVER_LOGIN_FORM_URL = `https://nid.naver.com/oauth2.0/authorize?re
 }&state=${import.meta.env.VITE_NAVER_CLIENT_SECRET}&redirect_uri=${
   import.meta.env.VITE_NAVER_CALLBACK_URL
 }&scope=name,email,profile_imagse,nickname`;
+
+export const DEBOUNCE_TIME = 500;


### PR DESCRIPTION
## 이슈 번호
#226, #152

## 완료한 기능 명세
- 키워드 검색 & 추천 키워드 검색
<img width="1215" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/fe988c06-4dc7-4b94-8ba7-30389953a639">

- 제목 + 내용 검색
<img width="1217" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/94adc242-a367-4bb9-9842-3d26c4cba40c">

- 검색 API 연동 완료
  - 키워드 추천, 키워드 기반 검색, 제목 + 내용 (Elastic Search) 기반 검색 API
- 피드 API 연동 중
  - 500 에러 나서 백엔드 분들께 여쭤본 상황입니다! 고쳐주시면 이어서 마저 연동하겠습니다!
- 검색 디바운싱 적용
  - useEffect, setTimeout 활용하여 디바운싱 적용 
