### PR TITLE
[FE] 친구 관리 요청을 보낸 후에 리렌더링이 되지 않는 문제 수정

### DIFF
--- a/frontend/src/api/FriendModal.ts
+++ b/frontend/src/api/FriendModal.ts
@@ -76,7 +76,7 @@ export const requestFriend = async (receiverId: number) => {
 export const cancelRequestFriend = async (receiverId: number) => {
   try {
     const response = await fetch(API_PATH.FRIEND.request(receiverId), {
-      method: 'delete',
+      method: 'DELETE',
       credentials: 'include',
     });
 
@@ -89,7 +89,7 @@ export const cancelRequestFriend = async (receiverId: number) => {
 export const deleteFriend = async (friendId: number) => {
   try {
     const response = await fetch(API_PATH.FRIEND.list(friendId), {
-      method: 'delete',
+      method: 'DELETE',
       credentials: 'include',
     });
 
@@ -119,7 +119,7 @@ export const allowFriend = async (senderId: number) => {
 export const rejectFriend = async (senderId: number) => {
   try {
     const response = await fetch(API_PATH.FRIEND.allow(senderId), {
-      method: 'delete',
+      method: 'DELETE',
       credentials: 'include',
     });
 

--- a/frontend/src/components/Home/FriendModalItem.tsx
+++ b/frontend/src/components/Home/FriendModalItem.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { cancelRequestFriend, deleteFriend, allowFriend, rejectFriend } from '@api/FriendModal';
 
@@ -18,21 +18,46 @@ const FriendModalItem = ({ email, profileImage, nickname, id, type }: FriendModa
   const goFriendHome = () => {
     navigate(`${PAGE_URL.HOME}${id}`);
   };
+  const queryClient = useQueryClient();
 
   const cancelRequestMutation = useMutation({
     mutationFn: (receiverId: number) => cancelRequestFriend(receiverId),
+    onSuccess() {
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: ['sendList'],
+        });
+      }, 100);
+    },
   });
 
   const deleteFriendMutation = useMutation({
     mutationFn: (friendId: number) => deleteFriend(friendId),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: ['friendList'],
+      });
+    },
   });
 
   const allowFriendMutation = useMutation({
     mutationFn: (senderId: number) => allowFriend(senderId),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: ['receivedList'],
+      });
+    },
   });
 
   const rejectFriendMutation = useMutation({
     mutationFn: (senderId: number) => rejectFriend(senderId),
+    onSuccess() {
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: ['receivedList'],
+        });
+      }, 100);
+    },
   });
 
   const getButtonElement = (type: string) => {

--- a/frontend/src/components/Home/FriendModalItem.tsx
+++ b/frontend/src/components/Home/FriendModalItem.tsx
@@ -13,6 +13,8 @@ interface FriendModalItemProps {
   type: string;
 }
 
+const DB_WAITING_TIME = 100;
+
 const FriendModalItem = ({ email, profileImage, nickname, id, type }: FriendModalItemProps) => {
   const navigate = useNavigate();
   const goFriendHome = () => {
@@ -27,7 +29,7 @@ const FriendModalItem = ({ email, profileImage, nickname, id, type }: FriendModa
         queryClient.invalidateQueries({
           queryKey: ['sendList'],
         });
-      }, 100);
+      }, DB_WAITING_TIME);
     },
   });
 
@@ -56,7 +58,7 @@ const FriendModalItem = ({ email, profileImage, nickname, id, type }: FriendModa
         queryClient.invalidateQueries({
           queryKey: ['receivedList'],
         });
-      }, 100);
+      }, DB_WAITING_TIME);
     },
   });
 

--- a/frontend/src/components/Home/ProfileEdit.tsx
+++ b/frontend/src/components/Home/ProfileEdit.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { updateProfile } from '@api/FriendModal';
 
@@ -9,6 +9,9 @@ interface ProfileEditProps {
 }
 
 const ProfileEdit = ({ profileImage, nickname }: ProfileEditProps) => {
+  const queryClient = useQueryClient();
+  const userId = localStorage.getItem('userId');
+
   const [newNickname, setNewNickname] = useState('');
   const [imageSrc, setImageSrc] = useState(profileImage);
   const [newProfileImage, setNewProfileImage] = useState<File>();
@@ -16,6 +19,11 @@ const ProfileEdit = ({ profileImage, nickname }: ProfileEditProps) => {
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateProfile(formData),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: ['profileData', userId],
+      });
+    },
   });
 
   const onChangeNickname = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 이슈 번호
#240 

## 완료한 기능 명세
- 프로필 변경 시 홈페이지의 프로필 데이터를 새로 받아오도록 수정
- 친구관련 요청 시 친구관리에 출력할 데이터를 새로 받아오도록 수정

