### PR TITLE
[FE] 감정 통계 API 재설정 & 통계 기간 input min, max 설정

### DIFF
--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import getEmotionStat from '@api/EmotionStat';
 
 import { formatDateDash, calPrev } from '@util/funcs';
-import { NEXT_INDEX, PREV_INDEX, PREV_WEEK } from '@/util/constants';
+import { NEXT_INDEX, PREV_INDEX, PREV_WEEK } from '@util/constants';
 
 interface EmotionStatProps {
   nickname: string;

--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -3,23 +3,18 @@ import { useQuery } from '@tanstack/react-query';
 
 import getEmotionStat from '@api/EmotionStat';
 
-import { formatDateDash } from '@util/funcs';
+import { formatDateDash, calPrev } from '@util/funcs';
+import { NEXT_INDEX, PREV_INDEX, PREV_WEEK } from '@/util/constants';
 
 interface EmotionStatProps {
   nickname: string;
 }
 
-const calPrevOneWeek = () => {
-  const date = new Date();
-  date.setDate(date.getDate() - 7);
-  return date;
-};
-
 const EmotionStat = ({ nickname }: EmotionStatProps) => {
-  const [period, _] = useState([calPrevOneWeek(), new Date()]);
+  const [period, setPeriod] = useState([calPrev(new Date(), PREV_WEEK), new Date()]);
 
   const { isError, isLoading } = useQuery({
-    queryKey: ['emotionStat', localStorage.getItem('userId')],
+    queryKey: ['emotionStat', localStorage.getItem('userId'), period],
     queryFn: () =>
       getEmotionStat(
         Number(localStorage.getItem('userId')),
@@ -45,12 +40,21 @@ const EmotionStat = ({ nickname }: EmotionStatProps) => {
             className="border-brown rounded-xl border border-solid p-3 outline-none"
             type="date"
             defaultValue={formatDateDash(period[0])}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setPeriod([new Date(e.target.value), period[1]])
+            }
+            max={formatDateDash(calPrev(period[1], PREV_INDEX))}
           />
           <p>~</p>
           <input
             type="date"
             className="border-brown rounded-xl border border-solid p-3 outline-none"
             defaultValue={formatDateDash(period[1])}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setPeriod([period[0], new Date(e.target.value)])
+            }
+            min={formatDateDash(calPrev(period[0], NEXT_INDEX))}
+            max={formatDateDash(new Date())}
           />
         </div>
       </div>

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -15,7 +15,7 @@
   }
 
   .btn-large {
-    @apply w-1/3 h-14 text-xl ;
+    @apply w-1/3 h-14 text-xl;
   }
 
   .btn-default {
@@ -34,10 +34,29 @@
 ::-webkit-scrollbar {
   height: 10px;
 }
-::-webkit-scrollbar-thumb{
-  background-color: #C7C1BB;
+::-webkit-scrollbar-thumb {
+  background-color: #c7c1bb;
   border-radius: 10px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #D9D9D9;
+  background: #d9d9d9;
+}
+
+input[type='date'] {
+  position: relative;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  color: transparent;
+  cursor: pointer;
+}
+
+input[type='date'] {
+  -webkit-text-fill-color: #4b4b4b;
 }

--- a/frontend/src/util/constants.ts
+++ b/frontend/src/util/constants.ts
@@ -51,6 +51,7 @@ export const DUMMY_DATA = [
 
 export const NEXT_INDEX = 1;
 export const PREV_INDEX = -1;
+export const PREV_WEEK = -7;
 export const PAGE_TITLE_HOME = '님의 일기 목록';
 export const PAGE_TITLE_FEED = '친구들의 일기';
 export const HOME = 'home';

--- a/frontend/src/util/funcs.ts
+++ b/frontend/src/util/funcs.ts
@@ -35,3 +35,9 @@ export const formatDateDash = (date: Date) => {
 
   return `${year}-${month}-${day}`;
 };
+
+export const calPrev = (date: Date, num: number) => {
+  const newDate = new Date(date);
+  newDate.setDate(newDate.getDate() + num);
+  return newDate;
+};


### PR DESCRIPTION
## 이슈 번호
#157
## 완료한 기능 명세
<img width="364" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/c89000a9-6234-483d-a8db-41593db6437b">
<img width="265" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/b82611fb-4454-4fdb-a2ac-ae4c2195f23c">

- 기간 변경 시 감정 통계 API 재요청되도록 queryKey 수정
- 통계 시작 날짜 => 통계 종료 날짜보다 후인 날짜 선택 못하도록 max 값 설정
- 통계 종료 날짜 => 통계 시작 날짜보다 전인 날짜 선택 못하도록 min 값 설정, 당일보다 후인 날짜 선택 못하도록 max 값 설정