### PR TITLE
[BE] 사용자 정보 조회 응답 수정 | lazy loading 삭제

### DIFF
--- a/backend/src/users/dto/user.dto.ts
+++ b/backend/src/users/dto/user.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional } from 'class-validator';
+import { FriendStatus } from 'src/friends/entity/friendStatus';
+
+class RelationDto {
+  senderId: number;
+  receiverId: number;
+  status: FriendStatus;
+}
 
 export class GetUserResponseDto {
   @ApiProperty({ description: '사용자 닉네임' })
@@ -13,6 +20,9 @@ export class GetUserResponseDto {
 
   @ApiProperty({ description: '오늘 일기 작성 여부' })
   isExistedTodayDiary: boolean;
+
+  @ApiProperty({ description: '해당 사용자와 친구인지 여부' })
+  relation: RelationDto;
 }
 
 export class SearchUserResponseDto {

--- a/backend/src/users/entity/user.entity.ts
+++ b/backend/src/users/entity/user.entity.ts
@@ -41,12 +41,12 @@ export class User extends BaseEntity {
   @DeleteDateColumn()
   deletedAt: Date;
 
-  @OneToMany(() => Diary, (diary) => diary.author, { cascade: true, lazy: true })
+  @OneToMany(() => Diary, (diary) => diary.author, { cascade: true })
   diaries: Diary[];
 
-  @OneToMany(() => Friend, (friend) => friend.sender, { cascade: true, lazy: true })
+  @OneToMany(() => Friend, (friend) => friend.sender, { cascade: true })
   sender: Friend[];
 
-  @OneToMany(() => Friend, (friend) => friend.receiver, { cascade: true, lazy: true })
+  @OneToMany(() => Friend, (friend) => friend.receiver, { cascade: true })
   receiver: Friend[];
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -55,15 +55,7 @@ export class UsersController {
   @ApiOperation({ description: '사용자 정보 조회 API' })
   @ApiOkResponse({ description: '사용자 정보 조회 성공', type: GetUserResponseDto })
   async getUserInfo(@Param('userId', ParseIntPipe) userId: number): Promise<GetUserResponseDto> {
-    const { user, totalFriends, isExistedTodayDiary } =
-      await this.usersService.findUserInfo(userId);
-
-    return {
-      nickname: user.nickname,
-      profileImage: user.profileImage,
-      totalFriends,
-      isExistedTodayDiary,
-    };
+    return await this.usersService.findUserInfo(userId);
   }
 
   @Get('/search/:nickname')

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -54,8 +54,11 @@ export class UsersController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '사용자 정보 조회 API' })
   @ApiOkResponse({ description: '사용자 정보 조회 성공', type: GetUserResponseDto })
-  async getUserInfo(@Param('userId', ParseIntPipe) userId: number): Promise<GetUserResponseDto> {
-    return await this.usersService.findUserInfo(userId);
+  async getUserInfo(
+    @User() user: UserEntity,
+    @Param('userId', ParseIntPipe) userId: number,
+  ): Promise<GetUserResponseDto> {
+    return this.usersService.findUserInfo(user.id, userId);
   }
 
   @Get('/search/:nickname')

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -3,9 +3,7 @@ import { DataSource, Repository } from 'typeorm';
 import { User } from './entity/user.entity';
 import { AuthUserDto } from '../auth/dto/auth.dto';
 import { SocialType } from './entity/socialType';
-import { FriendStatus } from 'src/friends/entity/friendStatus';
 import { endOfDay, startOfDay } from 'date-fns';
-import { GetUserResponseDto } from './dto/user.dto';
 
 @Injectable()
 export class UsersRepository extends Repository<User> {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,7 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { UsersRepository } from './users.repository';
 import { SearchUserResponseDto, UpdateUserProfileRequestDto } from './dto/user.dto';
-import { isToday } from 'date-fns';
 import { User } from './entity/user.entity';
 import { ImagesService } from 'src/images/images.service';
 
@@ -18,13 +17,7 @@ export class UsersService {
     if (!user) {
       throw new BadRequestException('존재하지 않는 사용자 정보입니다.');
     }
-    const sender = await user.sender;
-    const receiver = await user.receiver;
-    const diaries = await user.diaries;
-
-    const totalFriends = sender.length + receiver.length;
-    const isExistedTodayDiary = diaries.length !== 0 && isToday(diaries[0].createdAt);
-    return { user, totalFriends, isExistedTodayDiary };
+    return user;
   }
 
   async findUserById(userId: number) {


### PR DESCRIPTION
## 이슈 번호

#234 
#254

## 완료한 기능 명세

- [x] user entity lazy loading 삭제
- [x] 사용자 정보 조회 반환 값 수정

---

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/6b941d2d-b9d8-4cd5-987d-2dbc503db3ee)

- 잘 동작하는 것 같습니당....