### PR TITLE
[BE] 친구신청 상태와 관계없이 친구를 카운트하는 문제 수정

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -7,6 +7,7 @@ import {
 } from './dto/user.dto';
 import { User } from './entity/user.entity';
 import { ImagesService } from 'src/images/images.service';
+import { FriendStatus } from 'src/friends/entity/friendStatus';
 
 @Injectable()
 export class UsersService {
@@ -22,13 +23,19 @@ export class UsersService {
       throw new BadRequestException('존재하지 않는 사용자 정보입니다.');
     }
 
-    const totalFriends = user.sender.length + user.receiver.length;
-    const relation = [...user.sender, ...user.receiver].find((relation) => {
-      return (
-        (relation.receiver.id === userId && relation.sender.id === friendId) ||
-        (relation.receiver.id === friendId && relation.sender.id === friendId)
-      );
-    });
+    let totalFriends = 0;
+    let relation = null;
+    for (const friend of [...user.sender, ...user.receiver]) {
+      if (friend.status === FriendStatus.COMPLETE) {
+        totalFriends++;
+      }
+      if (
+        (friend.receiver.id === userId && friend.sender.id === friendId) ||
+        (friend.receiver.id === friendId && friend.sender.id === friendId)
+      ) {
+        relation = friend;
+      }
+    }
 
     return {
       nickname: user.nickname,

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -31,7 +31,7 @@ export class UsersService {
       }
       if (
         (friend.receiver.id === userId && friend.sender.id === friendId) ||
-        (friend.receiver.id === friendId && friend.sender.id === friendId)
+        (friend.receiver.id === friendId && friend.sender.id === userId)
       ) {
         relation = friend;
       }


### PR DESCRIPTION
## 이슈 번호

#254

## 완료한 기능 명세

- [x] 친구신청 상태와 관계없이 친구를 카운트하는 문제 수정
- [x] sender가 사용자 정보를 조회하면 relation을 반환할 수 없는 문제 수정 

--- 

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/08131169-eaa8-43d5-9496-31ad7033d7fb)

- ~~확인한줄 알았는데, 하나 놓쳤네요;; 죄송합니다...~~
- 확인한줄 알았는데,두개 놓쳤네요;; 죄송합니다...