### PR TITLE
[FE] 태그 검색 시 여러 개 검색 가능하도록 UI & 로직 수정

### DIFF
--- a/frontend/src/api/KeywordSearch.ts
+++ b/frontend/src/api/KeywordSearch.ts
@@ -1,5 +1,3 @@
-import { searchOptionsType } from '@type/pages/MyDiary';
-
 import API_PATH from '@util/apiPath';
 
 export const getTagRecommend = async (keyword: string) => {
@@ -16,19 +14,35 @@ export const getTagRecommend = async (keyword: string) => {
   }
 };
 
-export const getSearchResults = async ({
+export const getKeywordSearchResults = async ({
   pageParam,
 }: {
-  pageParam: { keyword: string; lastIndex: number; type: searchOptionsType };
+  pageParam: { keywordList: string[]; lastIndex: number };
 }) => {
   try {
-    const { keyword, lastIndex, type } = pageParam;
-    const fetchURL =
-      type === '키워드'
-        ? API_PATH.DIARY.keywordSearch(keyword, lastIndex)
-        : API_PATH.DIARY.search(keyword, lastIndex);
+    const { keywordList, lastIndex } = pageParam;
 
-    const response = await fetch(fetchURL, {
+    const response = await fetch(API_PATH.DIARY.keywordSearch(keywordList, lastIndex), {
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log('검색 결과 조회에 실패했습니다.', error);
+  }
+};
+
+export const getContentSearchResults = async ({
+  pageParam,
+}: {
+  pageParam: { contentSearchItem: string; lastIndex: number };
+}) => {
+  try {
+    const { contentSearchItem, lastIndex } = pageParam;
+
+    const response = await fetch(API_PATH.DIARY.search(contentSearchItem, lastIndex), {
       credentials: 'include',
     });
 

--- a/frontend/src/assets/image/icons.svg
+++ b/frontend/src/assets/image/icons.svg
@@ -45,4 +45,7 @@
   <symbol id="down" fill="none">
     <path d="M3.1875 6.375L8.5 12.75L13.8125 6.375H3.1875Z" fill="#BAC8BE"/>
   </symbol>
+  <symbol id="cancel" fill="none">
+    <path d="M4.78711 12.2137L8.5009 8.49992L12.2147 12.2137M12.2147 4.78613L8.50019 8.49992L4.78711 4.78613" stroke="#F96A6A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
 </svg>

--- a/frontend/src/components/Common/DiaryListItem.tsx
+++ b/frontend/src/components/Common/DiaryListItem.tsx
@@ -126,7 +126,7 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
       </div>
 
       <div className="mb-3 flex flex-wrap gap-3 text-base">
-        {diaryItem.tags.map((keyword, index) => (
+        {Array.from(diaryItem.tags).map((keyword, index) => (
           <Keyword key={index} text={keyword} />
         ))}
       </div>

--- a/frontend/src/components/MyDiary/KeywordSearch.tsx
+++ b/frontend/src/components/MyDiary/KeywordSearch.tsx
@@ -8,20 +8,23 @@ import Icon from '@components/Common/Icon';
 import { DEBOUNCE_TIME } from '@/util/constants';
 
 interface KeywordSearchProps {
-  keyword: string;
+  keywordList: string[];
   selected: searchOptionsType;
-  setKeyword: React.Dispatch<React.SetStateAction<string>>;
+  setKeywordList: React.Dispatch<React.SetStateAction<string[]>>;
   setSelected: React.Dispatch<React.SetStateAction<searchOptionsType>>;
   setSearchFlag: React.Dispatch<React.SetStateAction<boolean>>;
+  setContentSearchItem: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const KeywordSearch = ({
-  keyword,
+  keywordList,
   selected,
-  setKeyword,
+  setKeywordList,
   setSelected,
   setSearchFlag,
+  setContentSearchItem,
 }: KeywordSearchProps) => {
+  const [keyword, setKeyword] = useState('');
   const [showSelect, setShowSelect] = useState(false);
   const [showKeyword, setShowKeyword] = useState(false);
   const [recommendKeyword, setRecommendKeyword] = useState<string[]>();
@@ -31,6 +34,8 @@ const KeywordSearch = ({
       if (keyword) {
         const data = await getTagRecommend(keyword);
         setRecommendKeyword(data.keywords);
+      } else {
+        setSearchFlag(false);
       }
     }, DEBOUNCE_TIME);
     return () => clearTimeout(timer);
@@ -42,18 +47,40 @@ const KeywordSearch = ({
   const toggleShowKeyword = () => setShowKeyword((prev) => !prev);
 
   const onChangeSearchOption = (option: searchOptionsType) => {
+    if (option === '키워드' && selected === '제목 + 내용') {
+      setContentSearchItem('');
+    }
+    if (option === '제목 + 내용' && selected === '키워드') {
+      setKeywordList([]);
+    }
+    setRecommendKeyword([]);
     setSelected(option);
-    setSearchFlag(true);
     setShowSelect(false);
+    setKeyword('');
   };
+
   const onClickKeywordOption = (option: string) => {
-    setKeyword(option);
+    if (selected === '키워드') {
+      if (!keywordList.includes(option)) {
+        setKeywordList([option, ...keywordList]);
+      }
+      setKeyword('');
+    }
+    if (selected === '제목 + 내용') {
+      setContentSearchItem(option);
+      setKeyword(option);
+      setSearchFlag(true);
+    }
+    setRecommendKeyword([]);
     setShowKeyword(false);
   };
   const onChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchFlag(false);
     setKeyword(e.target.value);
     setShowKeyword(true);
+  };
+  const onClickKeywordCancel = (keywordItem: string) => {
+    setKeywordList(keywordList.filter((item) => item !== keywordItem));
   };
 
   return (
@@ -80,7 +107,7 @@ const KeywordSearch = ({
         )}
       </div>
       <div className="border-brown absolute left-36 z-50 flex w-auto flex-col rounded-xl border border-solid">
-        <div className="relative flex justify-between py-3 pl-4 pr-3">
+        <div className="flex justify-between py-3 pl-4 pr-3">
           <input
             className="outline-none"
             placeholder="검색어를 입력하세요"
@@ -112,6 +139,18 @@ const KeywordSearch = ({
                 ))}
             </div>
           </>
+        )}
+        {selected === '키워드' && (
+          <aside className="absolute top-14 -z-20 flex gap-2">
+            {keywordList.map((item) => (
+              <div className="border-mint flex items-center gap-1 rounded-lg border border-solid py-2 pl-3 pr-2 text-sm">
+                <p key={item}>{item}</p>
+                <button onClick={() => onClickKeywordCancel(item)}>
+                  <Icon id="cancel" size="small" />
+                </button>
+              </div>
+            ))}
+          </aside>
         )}
       </div>
     </section>

--- a/frontend/src/components/MyDiary/KeywordSearch.tsx
+++ b/frontend/src/components/MyDiary/KeywordSearch.tsx
@@ -5,7 +5,8 @@ import { getTagRecommend } from '@api/KeywordSearch';
 import { searchOptionsType } from '@type/pages/MyDiary';
 
 import Icon from '@components/Common/Icon';
-import { DEBOUNCE_TIME } from '@/util/constants';
+
+import { DEBOUNCE_TIME } from '@util/constants';
 
 interface KeywordSearchProps {
   keywordList: string[];

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -71,7 +71,7 @@ const MyDiary = () => {
           }
         : undefined;
     },
-    enabled: searchFlag && !!keyword,
+    enabled: !!searchFlag && !!keyword,
   });
 
   return (
@@ -100,7 +100,7 @@ const MyDiary = () => {
             keyword &&
             searchData?.pages.map((page, pageIndex) =>
               page.diaryList.map((item, itemIndex) => (
-                <DiaryListItem diaryItem={item} key={pageIndex + itemIndex} />
+                <DiaryListItem diaryItem={item} key={String(pageIndex) + String(itemIndex)} />
               )),
             )}
           {viewType === DIARY_VIEW_TYPE.WEEK && <WeekContainer />}

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -25,7 +25,7 @@ const API_PATH = {
     rud: (id: number) => SERVER_URL + DIARY + `/${id}`,
     search: (keyword: string, lastIndex: number) =>
       SERVER_URL + DIARY + '/search/v3' + `/${keyword}` + `?lastIndex=${lastIndex}`,
-    keywordSearch: (keyword: string, lastIndex: number) =>
+    keywordSearch: (keyword: string[], lastIndex: number) =>
       SERVER_URL + DIARY + TAG + `/${keyword}` + `?lastIndex=${lastIndex}`,
     feed: (lastIndex: number) => SERVER_URL + DIARY + `/friends?lastIndex=${lastIndex}`,
     grass: (id: number) => SERVER_URL + DIARY + '/mood' + `/${id}`,


### PR DESCRIPTION
## 이슈 번호
#257

## 완료한 기능 명세
- 태그 추천 동작 👌🏻
<img width="1261" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/24583bda-5078-49ae-9f66-42b27ae21f37">

- 추천된 태그 선택 시 인풋창 밑에 표시
<img width="1289" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/6008cc8c-fa2d-4f6f-b824-d3c30d9046f3">

- 제목 + 내용 선택 시 하나만 선택 가능
<img width="1228" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/cd887718-d173-4867-b569-da69800e3106">
