### PR TITLE
[BE] friends, reactions module 쿼리 개선

### DIFF
--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -224,7 +224,8 @@ export class DiariesRepository extends Repository<Diary> {
   ): Promise<GetYearMoodResponseDto[]> {
     const diaries = await this.createQueryBuilder('diary')
       .select(['diary.createdAt as date', 'diary.mood as mood'])
-      .where('diary.createdAt BETWEEN :startDate AND :lastDate', { startDate, lastDate })
+      .where('diary.authorId = :userId', { userId })
+      .andWhere('diary.createdAt BETWEEN :startDate AND :lastDate', { startDate, lastDate })
       .getRawMany();
 
     return diaries.map((diary) => ({

--- a/backend/src/reactions/reactions.controller.ts
+++ b/backend/src/reactions/reactions.controller.ts
@@ -11,7 +11,7 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User as UserEntity } from 'src/users/entity/user.entity';
 import { User } from 'src/users/utils/user.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
@@ -28,19 +28,10 @@ export class ReactionsController {
   @ApiOperation({ description: '리액션 조회 API' })
   @ApiOkResponse({ description: '리액션 조회 성공' })
   async getReactions(
-    @User() user: UserEntity,
     @Param('diaryId', ParseIntPipe) diaryId: number,
   ): Promise<Record<string, ReactionInfoResponseDto[]>> {
-    const reactions = await this.reactionsService.getAllReaction(user, diaryId);
+    const reactionList = await this.reactionsService.getAllReaction(diaryId);
 
-    const reactionList = reactions.map<ReactionInfoResponseDto>((reaction) => {
-      return {
-        userId: reaction.user.id,
-        nickname: reaction.user.nickname,
-        profileImage: reaction.user.profileImage,
-        reaction: reaction.reaction,
-      };
-    });
     return { reactionList };
   }
 

--- a/backend/src/reactions/reactions.repository.ts
+++ b/backend/src/reactions/reactions.repository.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { Reaction } from './entity/reaction.entity';
 import { Diary } from 'src/diaries/entity/diary.entity';
 import { User } from 'src/users/entity/user.entity';
+import { ReactionInfoResponseDto } from './dto/reaction.dto';
 
 @Injectable()
 export class ReactionsRepository extends Repository<Reaction> {
@@ -29,12 +30,16 @@ export class ReactionsRepository extends Repository<Reaction> {
     });
   }
 
-  async findByDiary(diary: Diary) {
-    return this.find({
-      where: {
-        diary: { id: diary.id },
-      },
-      relations: ['user'],
-    });
+  findByDiary(diaryId: number): Promise<ReactionInfoResponseDto[]> {
+    return this.createQueryBuilder('reaction')
+      .select([
+        'user.id as userId',
+        'user.nickname as nickname',
+        'user.profileImage as profileImage',
+        'reaction.reaction as reaction',
+      ])
+      .where('reaction.diaryId = :diaryId', { diaryId })
+      .innerJoin('reaction.user', 'user')
+      .getRawMany();
   }
 }

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -11,10 +11,8 @@ export class ReactionsService {
     private readonly diariesService: DiariesService,
   ) {}
 
-  async getAllReaction(user: User, diaryId: number) {
-    const diary = await this.diariesService.findDiary(user, diaryId);
-
-    return await this.reactionsRepository.findByDiary(diary);
+  getAllReaction(diaryId: number) {
+    return this.reactionsRepository.findByDiary(diaryId);
   }
 
   async saveReaction(user: User, diaryId: number, reactionRequestDto: ReactionRequestDto) {


### PR DESCRIPTION
## 이슈 번호

#227 

## 완료한 기능 명세

- friends repository에서는 고칠만한 함수가 하난데 이것도 service의 두 곳에서 사용되고 있어서 dto type으로 반환하려면 분리해야하더라구요...? 고민하다가 일단 select에 필드만 특정했습니다. 좋은 의견 있으시면 말씀해주십셔 😊
  ![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/84311260-27e2-4963-b9fc-24c825f96fd4)

- reactions module 쿼리 개선
  
  ![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/fd3a1984-4c36-45af-8b43-dcbd881a592e)

- diaries repository에 하나 빠진게 있어서 수정했습니다.