### PR TITLE
[BE] access token 갱신 에러 해결

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,7 +3,6 @@ import { ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { Request, Response } from 'express';
 import { OAuthLoginDto, OAuthLoginResponseDto } from './dto/auth.dto';
-import { SERVICE_URL } from './utils/auth.constant';
 
 @ApiTags('Authentication API')
 @Controller('auth')
@@ -27,7 +26,7 @@ export class AuthController {
     const newJwt = await this.authService.refreshAccessToken(req);
 
     res.cookie('utk', newJwt, { httpOnly: true });
-    res.redirect(SERVICE_URL);
+    res.json({ message: 'access token 갱신에 성공했습니다.' });
   }
 
   @Post('logout')


### PR DESCRIPTION
## 이슈 번호

#265 

## 완료한 기능 명세
jwt를 발급할 때 `access key`를 부여하여 이걸로 refresh token을 redis에 저장.
이렇게 함으로써 jwt의 string값이 변경되어도 바뀌지 않는 `access key`가 있어서 refresh token을 찾을 수 있음!!

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/fb9ff6a5-747d-4e90-85fb-85b5a2678d09)

