### PR TITLE
[BE] 태그로 일기 조회 시 반환값 에러 수정

### DIFF
--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -166,11 +166,11 @@ export class DiariesController {
     type: ReadUserDiariesResponseDto,
   })
   async findDiaryByKeywordV1(
-    @User() author: UserEntity,
+    @User() user: UserEntity,
     @Param('keyword') keyword: string,
     @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    return await this.diariesService.findDiaryByKeywordV1(author, keyword, lastIndex);
+    return await this.diariesService.findDiaryByKeywordV1(user, keyword, lastIndex);
   }
 
   @Get('/search/v2/:keyword')
@@ -181,11 +181,11 @@ export class DiariesController {
     type: ReadUserDiariesResponseDto,
   })
   async findDiaryByKeywordV2(
-    @User() author: UserEntity,
+    @User() user: UserEntity,
     @Param('keyword') keyword: string,
     @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    return await this.diariesService.findDiaryByKeywordV2(author, keyword, lastIndex);
+    return await this.diariesService.findDiaryByKeywordV2(user, keyword, lastIndex);
   }
 
   @Get('/search/v3/:keyword')
@@ -196,13 +196,13 @@ export class DiariesController {
     type: ReadUserDiariesResponseDto,
   })
   async findDiaryByKeywordV3(
-    @User() author: UserEntity,
+    @User() user: UserEntity,
     @Param('keyword') keyword: string,
     @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaryList = await this.diariesService.findDiaryByKeywordV3(author, keyword, lastIndex);
+    const diaryList = await this.diariesService.findDiaryByKeywordV3(user, keyword, lastIndex);
 
-    return { nickname: author.nickname, diaryList };
+    return { nickname: user.nickname, diaryList };
   }
 
   @Get('/tags/:tagName')

--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
-  AllDiaryInfosDto,
   CreateDiaryDto,
   GetAllEmotionsRequestDto,
   GetAllEmotionsResponseDto,

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -235,7 +235,7 @@ export class DiariesRepository extends Repository<Diary> {
   }
 
   async findDiaryByKeywordV1(
-    authorId: number,
+    userId: number,
     keyword: string,
     lastIndex: number,
   ): Promise<AllDiaryInfosDto[]> {
@@ -252,7 +252,7 @@ export class DiariesRepository extends Repository<Diary> {
         'COUNT(reactions.reaction) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
-      .where('diary.author.id = :authorId', { authorId })
+      .where('diary.author.id = :userId', { userId })
       .andWhere('diary.content LIKE :keyword OR diary.title LIKE :keyword', {
         keyword: `%${keyword}%`,
       })
@@ -271,13 +271,13 @@ export class DiariesRepository extends Repository<Diary> {
     diaryInfos.forEach((diaryInfo) => {
       diaryInfo.tags = diaryInfo.tags ? diaryInfo.tags.split(',') : [];
       diaryInfo.reactionCount = Number(diaryInfo.reactionCount);
-      this.mapToLeaveReaction(diaryInfo, authorId);
+      this.mapToLeaveReaction(diaryInfo, userId);
     });
     return diaryInfos;
   }
 
   async findDiaryByKeywordV2(
-    authorId: number,
+    userId: number,
     keyword: string,
     lastIndex: number,
   ): Promise<AllDiaryInfosDto[]> {
@@ -294,7 +294,7 @@ export class DiariesRepository extends Repository<Diary> {
         'COUNT(reactions.reaction) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
-      .where('diary.author.id = :authorId', { authorId })
+      .where('diary.author.id = :userId', { userId })
       .andWhere(
         '(MATCH(diary.content) AGAINST(:keyword IN BOOLEAN MODE) OR MATCH(diary.title) AGAINST(:keyword IN BOOLEAN MODE))',
         { keyword: `*${keyword}*` },
@@ -314,13 +314,13 @@ export class DiariesRepository extends Repository<Diary> {
     diaryInfos.forEach((diaryInfo) => {
       diaryInfo.tags = diaryInfo.tags ? diaryInfo.tags.split(',') : [];
       diaryInfo.reactionCount = Number(diaryInfo.reactionCount);
-      this.mapToLeaveReaction(diaryInfo, authorId);
+      this.mapToLeaveReaction(diaryInfo, userId);
     });
     return diaryInfos;
   }
 
   async findDiaryByKeywordV3(
-    id: number,
+    userId: number,
     keyword: string,
     lastIndex: number,
   ): Promise<SearchDiaryDataForm[]> {
@@ -345,7 +345,7 @@ export class DiariesRepository extends Repository<Diary> {
         query: {
           bool: {
             must: [
-              { term: { authorid: id } },
+              { term: { authorid: userId } },
               {
                 bool: {
                   should: [{ match: { content: keyword } }, { match: { title: keyword } }],

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -225,7 +225,9 @@ export class DiariesService {
     const diaries = await this.diariesRepository.findDiaryByKeywordV3(user.id, keyword, lastIndex);
 
     return diaries.map<AllDiaryInfosDto>((diary) => {
-      const reactionIndex = diary.reactionUsers.findIndex((userId) => userId === user.id);
+      const reactionIndex = diary.reactionUsers.findIndex(
+        (reactionUserId) => reactionUserId === user.id,
+      );
 
       return {
         diaryId: diary.diaryid,

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -196,48 +196,36 @@ export class DiariesService {
   }
 
   async findDiaryByKeywordV1(
-    author: User,
+    user: User,
     keyword: string,
     lastIndex: number,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaries = await this.diariesRepository.findDiaryByKeywordV1(
-      author.id,
-      keyword,
-      lastIndex,
-    );
+    const diaries = await this.diariesRepository.findDiaryByKeywordV1(user.id, keyword, lastIndex);
 
-    return { nickname: author.nickname, diaryList: diaries };
+    return { nickname: user.nickname, diaryList: diaries };
   }
 
-  async findDiaryByKeywordV2(author: User, keyword: string, lastIndex: number) {
-    const diaries = await this.diariesRepository.findDiaryByKeywordV2(
-      author.id,
-      keyword,
-      lastIndex,
-    );
+  async findDiaryByKeywordV2(user: User, keyword: string, lastIndex: number) {
+    const diaries = await this.diariesRepository.findDiaryByKeywordV2(user.id, keyword, lastIndex);
 
-    return { nickname: author.nickname, diaryList: diaries };
+    return { nickname: user.nickname, diaryList: diaries };
   }
 
   async findDiaryByTag(
-    author: User,
+    user: User,
     tagName: string,
     lastIndex: number | undefined,
   ): Promise<ReadUserDiariesResponseDto> {
-    const diaries = await this.diariesRepository.findDiaryByTag(author.id, tagName, lastIndex);
+    const diaries = await this.diariesRepository.findDiaryByTag(user.id, tagName, lastIndex);
 
-    return { nickname: author.nickname, diaryList: diaries };
+    return { nickname: user.nickname, diaryList: diaries };
   }
 
-  async findDiaryByKeywordV3(author: User, keyword: string, lastIndex: number) {
-    const diaries = await this.diariesRepository.findDiaryByKeywordV3(
-      author.id,
-      keyword,
-      lastIndex,
-    );
+  async findDiaryByKeywordV3(user: User, keyword: string, lastIndex: number) {
+    const diaries = await this.diariesRepository.findDiaryByKeywordV3(user.id, keyword, lastIndex);
 
     return diaries.map<AllDiaryInfosDto>((diary) => {
-      const reactionIndex = diary.reactionUsers.findIndex((userId) => userId === author.id);
+      const reactionIndex = diary.reactionUsers.findIndex((userId) => userId === user.id);
 
       return {
         diaryId: diary.diaryid,


### PR DESCRIPTION
## 이슈 번호

#266 

## 완료한 기능 명세
![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/5d724c1b-6008-4078-ae99-e8a38866d60d)

- 태그로 일기 조회 시 반환값 에러 수정
- diaries module의 `user`, `author` 변수명 통일