### PR TITLE
[BE] 친구 없는 사용자가 피드 조회 시 발생하는 에러 해결

### DIFF
--- a/backend/src/diaries/diaries.controller.ts
+++ b/backend/src/diaries/diaries.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
-  AllDiaryInfosDto,
   CreateDiaryDto,
   GetAllEmotionsRequestDto,
   GetAllEmotionsResponseDto,
@@ -58,11 +57,11 @@ export class DiariesController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '피드 일기 조회 API' })
   @ApiOkResponse({ description: '피드 일기 조회 성공', type: FeedDiaryDto })
-  async getFeedDiary(
+  async findFeedDiary(
     @User() user: UserEntity,
     @Query('lastIndex', new ParseIntPipe({ optional: true })) lastIndex: number,
   ): Promise<Record<string, FeedDiaryDto[]>> {
-    const diaryList = await this.diariesService.getFeedDiary(user.id, lastIndex);
+    const diaryList = await this.diariesService.findFeedDiary(user.id, lastIndex);
 
     return { diaryList };
   }

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -145,12 +145,17 @@ export class DiariesService {
     }, []);
   }
 
-  async getFeedDiary(userId: number, lastIndex: number | undefined): Promise<FeedDiaryDto[]> {
+  async findFeedDiary(userId: number, lastIndex: number | undefined): Promise<FeedDiaryDto[]> {
     const today = new Date();
     const oneWeekAgo = new Date(today);
     oneWeekAgo.setDate(today.getDate() - 7);
 
     const friends = await this.friendsService.getFriendsList(userId);
+
+    if (friends.length === 0) {
+      return [];
+    }
+
     const friendsIdList = friends.map((friend) => friend.id);
 
     return await this.diariesRepository.findPaginatedDiaryByDateAndIdList(


### PR DESCRIPTION
## 이슈 번호

#282 

## 완료한 기능 명세

친구 목록이 없는 경우 `where('diary.author IN (:...idList)', { idList })` 부분에서 idList가 없어서 에러가 나는 것 같아 친구 목록이 없는 경우 빈 배열을 리턴하도록 했습니다.