### PR TITLE
[FE] 무한스크롤 IntersectionObserver 적용

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
@@ -8,16 +9,17 @@ import { InfiniteDiaryListProps } from '@type/components/Common/DiaryList';
 import { viewTypes } from '@type/pages/MyDiary';
 
 import NavBar from '@components/Common/NavBar';
-import DiaryList from '@components/Common/DiaryList';
+import DiaryListItem from '@components/Common/DiaryListItem';
 import Profile from '@components/Home/Profile';
 import Grass from '@components/Home/Grass';
 import EmotionStat from '@components/Home/EmotionStat';
 
-import { HOME } from '@util/constants';
+import { PAGE_TITLE_HOME } from '@util/constants';
 
 const Home = () => {
   const params = useParams();
   const userId = params.userId ? params.userId : localStorage.getItem('userId');
+  const infiniteRef = useRef<HTMLDivElement>(null);
 
   const {
     data: profileData,
@@ -28,7 +30,11 @@ const Home = () => {
     queryFn: () => getCurrentUser(userId ? +userId : 0),
   });
 
-  const { data: diaryData } = useInfiniteQuery<
+  const {
+    data: diaryData,
+    fetchNextPage,
+    isSuccess,
+  } = useInfiniteQuery<
     any,
     Error,
     InfiniteDiaryListProps,
@@ -53,6 +59,19 @@ const Home = () => {
     },
   });
 
+  useEffect(() => {
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          fetchNextPage();
+        }
+      });
+    });
+    if (infiniteRef.current) {
+      io.observe(infiniteRef.current);
+    }
+  }, [isSuccess]);
+
   if (isLoading) {
     return <p>Loading...</p>;
   }
@@ -67,14 +86,15 @@ const Home = () => {
       <Profile userId={userId ? +userId : 0} userData={profileData} />
       <Grass />
       <EmotionStat nickname={profileData.nickname} />
-      {diaryData?.pages.map((page, index) => (
-        <DiaryList
-          key={index}
-          pageType={HOME}
-          diaryData={page.diaryList}
-          username={page.nickname}
-        />
-      ))}
+      <div className="w-3/5 p-5">
+        <h1 className="mb-5 text-2xl font-bold">{`${profileData.nickname}${PAGE_TITLE_HOME}`}</h1>
+        {diaryData?.pages.map((page, pageIndex) =>
+          page.diaryList.map((item, itemIndex) => (
+            <DiaryListItem diaryItem={item} key={Number(String(pageIndex) + String(itemIndex))} />
+          )),
+        )}
+      </div>
+      <div ref={infiniteRef} />
     </main>
   );
 };


### PR DESCRIPTION
## 이슈 번호
#159

## 완료한 기능 명세

https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/2deae13f-3d67-4b05-b2b6-692ee7c8fc39

- intersectionObserver를 적용하여 reflow 없이 요소가 뷰포트 내에 들어왔는지 확인, 들어왔을 경우 다음 데이터 가져옴
