### PR TITLE
[FE] 내가 작성한 일기 (주) 애니메이션 적용 & 버그 수정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "html-react-parser": "^5.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.18.0"
+    "react-router-dom": "^6.18.0",
+    "swiper": "^11.0.5"
   },
   "devDependencies": {
     "@toast-ui/editor": "^3.2.2",

--- a/frontend/src/api/EmotionStat.ts
+++ b/frontend/src/api/EmotionStat.ts
@@ -8,7 +8,7 @@ const getEmotionStat = async (id: number, startDate: string, endDate: string) =>
       credentials: 'include',
     });
 
-    if (!response.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
+    if (!response?.ok) throw new Error('올바른 네트워크 응답이 아닙니다.');
     const data = await response.json();
     return data;
   } catch (error) {

--- a/frontend/src/api/fetchInterceptor.ts
+++ b/frontend/src/api/fetchInterceptor.ts
@@ -9,7 +9,7 @@ const interceptor = async (url: string, option: any) => {
 
   const refreshResponse = await refresh();
 
-  if (!response.ok) {
+  if (refreshResponse?.status === 401 || refreshResponse?.status === 500) {
     localStorage.clear();
     window.location.href = PAGE_URL.LOGIN;
     return refreshResponse;

--- a/frontend/src/api/fetchInterceptor.ts
+++ b/frontend/src/api/fetchInterceptor.ts
@@ -9,7 +9,7 @@ const interceptor = async (url: string, option: any) => {
 
   const refreshResponse = await refresh();
 
-  if (refreshResponse?.status === 401) {
+  if (!response.ok) {
     localStorage.clear();
     window.location.href = PAGE_URL.LOGIN;
     return refreshResponse;

--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
 
 import getEmotionStat from '@api/EmotionStat';
 import EmotionCloud from '@components/Home/EmotionCloud';
@@ -27,16 +28,14 @@ interface diaryInfoProps {
 }
 
 const EmotionStat = ({ nickname }: EmotionStatProps) => {
+  const params = useParams();
+  const userId = params.userId ? params.userId : localStorage.getItem('userId');
   const [period, setPeriod] = useState([calPrev(new Date(), PREV_WEEK), new Date()]);
 
   const { data, isError, isLoading } = useQuery({
-    queryKey: ['emotionStat', localStorage.getItem('userId'), period],
+    queryKey: ['emotionStat', userId, period],
     queryFn: () =>
-      getEmotionStat(
-        Number(localStorage.getItem('userId')),
-        formatDateDash(period[0]),
-        formatDateDash(period[1]),
-      ),
+      getEmotionStat(Number(userId), formatDateDash(period[0]), formatDateDash(period[1])),
   });
 
   if (isLoading) {
@@ -54,7 +53,7 @@ const EmotionStat = ({ nickname }: EmotionStatProps) => {
   const eData = (data?.emotions || []).map((item: emotionCloudProps) => {
     return {
       text: item.emotion,
-      size: item.diaryInfo.length / totalLength * 200,
+      size: (item.diaryInfo.length / totalLength) * 200,
     };
   });
 

--- a/frontend/src/components/Home/FriendModalItem.tsx
+++ b/frontend/src/components/Home/FriendModalItem.tsx
@@ -122,7 +122,7 @@ const FriendModalItem = ({ email, profileImage, nickname, id, type }: FriendModa
     <div className="mb-5 mr-3 flex w-full">
       <div className="w-28">
         <img
-          className="mr-3 h-16 w-16 cursor-pointer rounded-full"
+          className="mr-3 h-16 w-16 cursor-pointer rounded-full object-cover"
           onClick={goFriendHome}
           src={profileImage}
           alt={`${nickname} 프로필 이미지`}

--- a/frontend/src/components/MyDiary/Card.tsx
+++ b/frontend/src/components/MyDiary/Card.tsx
@@ -96,7 +96,7 @@ const Card = ({ diaryItem, styles, size }: CardProps) => {
 
   return (
     <div
-      className={`border-brown relative flex flex-col gap-3 rounded-xl border border-solid px-7 py-6 ${styles}`}
+      className={`border-brown relative flex flex-col gap-3 rounded-xl border border-solid bg-white px-7 py-6 ${styles}`}
     >
       <div onClick={goDetail} className="flex cursor-pointer flex-col gap-2">
         <p className={`${size === SMALL ? 'text-sm' : ''}`}>

--- a/frontend/src/components/MyDiary/CarouselContainer.tsx
+++ b/frontend/src/components/MyDiary/CarouselContainer.tsx
@@ -1,34 +1,54 @@
-import { useState } from 'react';
+import { useRef } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { EffectCards } from 'swiper/modules';
+import SwiperClass from 'swiper';
+
+import 'swiper/css';
+import 'swiper/css/effect-cards';
 
 import { IDiaryContent } from '@type/components/Common/DiaryList';
 
 import Icon from '@components/Common/Icon';
 import Card from '@components/MyDiary/Card';
 
-import { PREV_INDEX, LARGE, NEXT_INDEX, SMALL } from '@util/constants';
+import { LARGE } from '@util/constants';
 
 interface CarouselContainerProps {
   data: IDiaryContent[];
 }
 
 const CarouselContainer = ({ data }: CarouselContainerProps) => {
-  const [activeIndex, setActiveIndex] = useState(0);
-  const dataLength = data.length;
-  const prevIndex =
-    activeIndex === 0 ? activeIndex + PREV_INDEX + dataLength : activeIndex + PREV_INDEX;
+  const swiperRef = useRef<SwiperClass>();
+  const swiperOptions = {
+    slideShadows: false,
+  };
 
   return (
-    <section className="flex w-full items-center justify-center">
-      <Card diaryItem={data[prevIndex]} styles="w-1/3" size={SMALL} />
-      <button onClick={() => setActiveIndex(prevIndex)}>
-        <Icon id="largeLeftArrow" size={LARGE} />
-      </button>
-      <Card diaryItem={data[activeIndex]} styles="w-2/3" />
-      <button onClick={() => setActiveIndex((activeIndex + NEXT_INDEX) % dataLength)}>
-        <Icon id="largeRightArrow" size={LARGE} />
-      </button>
-      <Card diaryItem={data[(activeIndex + NEXT_INDEX) % dataLength]} styles="w-1/3" size={SMALL} />
-    </section>
+    <>
+      <section className="flex w-full justify-center">
+        <button onClick={() => swiperRef.current?.slidePrev()}>
+          <Icon id="largeLeftArrow" size={LARGE} />
+        </button>
+        <Swiper
+          effect={'cards'}
+          grabCursor={true}
+          modules={[EffectCards]}
+          className="m-10 w-1/2"
+          cardsEffect={swiperOptions}
+          loop={true}
+          onSwiper={(swiper) => (swiperRef.current = swiper)}
+        >
+          {data.map((item, index) => (
+            <SwiperSlide key={index}>
+              <Card diaryItem={item} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+        <button onClick={() => swiperRef.current?.slideNext()}>
+          <Icon id="largeRightArrow" size={LARGE} />
+        </button>
+      </section>
+    </>
   );
 };
 

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -60,3 +60,7 @@ input[type='date']::-webkit-calendar-picker-indicator {
 input[type='date'] {
   -webkit-text-fill-color: #4b4b4b;
 }
+
+.swiper-slide {
+  border-radius: 0.75rem;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8456,6 +8456,11 @@ swagger-ui-dist@5.9.1:
   resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.9.1.tgz#d0bcd614e3752da02df141846348f84468ae815e"
   integrity sha512-5zAx+hUwJb9T3EAntc7TqYkV716CMqG6sZpNlAAMOMWkNXRYxGkN8ADIvD55dQZ10LxN90ZM/TQmN7y1gpICnw==
 
+swiper@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-11.0.5.tgz#6ed1ad06e6906ba42fd4b93d4988f0626a49046e"
+  integrity sha512-rhCwupqSyRnWrtNzWzemnBLMoyYuoDgGgspAm/8iBD3jCvAWycPLH4Z3TB0O5520DHLzMx94yUMH/B9Efpa48w==
+
 symbol-observable@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"


### PR DESCRIPTION
## 이슈 번호
#264, #286, #287, #288

## 완료한 기능 명세

https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/45e3fe42-7518-4c97-b55e-ecc35467ff1d

- Swiper.js 활용하여 캐러셀에 카드 애니메이션 적용
- fetch Interceptor 조건문 수정
  - refreshResponse의 status가 401 혹은 500일 때 재로그인 요청
- 친구 홈에서 감정 통계가 현재 로그인한 유저의 것으로 보이는 문제 해결
  
<img width="889" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/72236dec-288a-4484-bfaf-bba277a03b78">
<img width="869" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/6e2da46c-8309-4ed8-93c9-90f2c63bb865">

- 친구 모달의 프로필 사진이 찌그러지는 문제 해결
<img width="428" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/27264465-4081-4f32-902e-58484180d2e1">
