### PR TITLE
[BE] 태그가 여러번 출력되는 문제 수정

### DIFF
--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -48,8 +48,8 @@ export class DiariesRepository extends Repository<Diary> {
         'user.nickname as authorName',
         'user.profileImage as profileImage',
 
-        'GROUP_CONCAT(tags.name) as tagNames',
-        'COUNT(reactions.reaction) as reactionCount',
+        'GROUP_CONCAT(DISTINCT tags.name) as tagNames',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
       ])
       .where('diary.id = :id', { id })
       .leftJoin('diary.tags', 'tags')
@@ -121,8 +121,8 @@ export class DiariesRepository extends Repository<Diary> {
         'diary.createdAt as createdAt',
         'diary.emotion as emotion',
 
-        'GROUP_CONCAT(tags.name) as tags',
-        'COUNT(reactions.reaction) as reactionCount',
+        'GROUP_CONCAT(DISTINCT tags.name) as tags',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
       .where('diary.author.id = :authorId', { authorId })
@@ -191,7 +191,7 @@ export class DiariesRepository extends Repository<Diary> {
         'user.profileImage as profileImage',
 
         'GROUP_CONCAT(DISTINCT tags.name) as tags',
-        'COUNT(reactions.reaction) as reactionCount',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
       .where('diary.author IN (:...idList)', { idList })
@@ -249,8 +249,8 @@ export class DiariesRepository extends Repository<Diary> {
         'diary.createdAt as createdAt',
         'diary.emotion as emotion',
 
-        'GROUP_CONCAT(tags.name) as tags',
-        'COUNT(reactions.reaction) as reactionCount',
+        'GROUP_CONCAT(DISTINCT tags.name) as tags',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
       .where('diary.author.id = :userId', { userId })
@@ -291,8 +291,8 @@ export class DiariesRepository extends Repository<Diary> {
         'diary.createdAt as createdAt',
         'diary.emotion as emotion',
 
-        'GROUP_CONCAT(tags.name) as tags',
-        'COUNT(reactions.reaction) as reactionCount',
+        'GROUP_CONCAT(DISTINCT tags.name) as tags',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
       .where('diary.author.id = :userId', { userId })
@@ -377,8 +377,8 @@ export class DiariesRepository extends Repository<Diary> {
         'diary.createdAt as createdAt',
         'diary.emotion as emotion',
 
-        'GROUP_CONCAT(tags.name) as tags',
-        'COUNT(reactions.reaction) as reactionCount',
+        'GROUP_CONCAT(DISTINCT tags.name) as tags',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
       .where('diary.author.id = :userId', { userId })

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -78,7 +78,7 @@ export class DiariesRepository extends Repository<Diary> {
         'diary.createdAt as createdAt',
         'diary.emotion as emotion',
 
-        'GROUP_CONCAT(tags.name) as tags',
+        'GROUP_CONCAT(DISTINCT tags.name) as tags',
         'COUNT(reactions.reaction) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
@@ -190,7 +190,7 @@ export class DiariesRepository extends Repository<Diary> {
         'user.nickname as nickname',
         'user.profileImage as profileImage',
 
-        'GROUP_CONCAT(tags.name) as tags',
+        'GROUP_CONCAT(DISTINCT tags.name) as tags',
         'COUNT(reactions.reaction) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -79,7 +79,7 @@ export class DiariesRepository extends Repository<Diary> {
         'diary.emotion as emotion',
 
         'GROUP_CONCAT(DISTINCT tags.name) as tags',
-        'COUNT(reactions.reaction) as reactionCount',
+        'COUNT(DISTINCT reactions.id) as reactionCount',
         'GROUP_CONCAT(CONCAT(reactions.userId, ":", reactions.reaction)) as leavedReaction',
       ])
       .where('diary.author.id = :authorId', { authorId })


### PR DESCRIPTION
## 이슈 번호

#301 

## 완료한 기능 명세

- [x] 태그가 여러번 출력되는 문제 수정

---

- 태그 중복 출력

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/2d66feb6-8da2-40a9-9cb1-63a517a44392)

리액션 갯수에 따라서 태그들이 리액션 수만큼 배가 되어 출력되는 문제가 있어 수정했습니다.

- 리액션 갯수 출력 오류

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/04110520-c981-46d2-b44c-8639ebfe1268)

태그를 고치다 보니 태그 갯수만큼 리액션도 배가 되는 문제가 있어 함께 수정했습니다.

저희가 leftJoin을 많이 사용하다보니 관련해서 문제가 좀 있었던 것 같습니다.;;