### PR TITLE
[FE] 단디 로고 배경색 변경

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,7 @@
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="favicon-128.png" sizes="128x128" />
-    <meta name="theme-color" content="#B5C6B0" />
+    <meta name="theme-color" content="#fffef9" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>단디</title>
   </head>

--- a/frontend/src/assets/image/logo.svg
+++ b/frontend/src/assets/image/logo.svg
@@ -1,8 +1,8 @@
 <svg width="136" height="50" viewBox="0 0 136 50" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect width="136" height="50" fill="none"/>
+<rect width="136" height="50" fill="#F5F5F5"/>
 <rect width="1440" height="1024" transform="translate(-652 -368)" fill="#D5E0D8"/>
 <g filter="url(#filter0_d_0_1)">
-<rect x="-213" y="-66" width="562" height="336" rx="30" fill="none"/>
+<rect x="-213" y="-66" width="562" height="336" rx="30" fill="white"/>
 </g>
 <rect width="136" height="50" fill="url(#pattern0)"/>
 <defs>

--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -53,7 +53,7 @@ const EmotionStat = ({ nickname }: EmotionStatProps) => {
   const eData = (data?.emotions || []).map((item: emotionCloudProps) => {
     return {
       text: item.emotion,
-      size: (item.diaryInfo.length / totalLength) * 200,
+      size: (item.diaryInfo.length / totalLength) * 100,
     };
   });
 


### PR DESCRIPTION
## 이슈 번호
#298 

## 완료한 기능 명세
<img width="395" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/d9664351-9bbf-4ab0-a116-b5048b751947">

- 로그인 페이지에서 단디 로고에 배경색이 들어간 것을 수정