### PR TITLE
[BE] 엘라스틱서치와 MySQL 데이터 동기화 방식 변경

### DIFF
--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -349,7 +349,7 @@ export class DiariesRepository extends Repository<Diary> {
         query: {
           bool: {
             must: [
-              { term: { authorid: 15 } },
+              { term: { authorid: userId } },
               {
                 multi_match: {
                   query: keyword,

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -359,7 +359,7 @@ export class DiariesRepository extends Repository<Diary> {
             ],
           },
         },
-        sort: [{ diaryId: 'desc' }],
+        sort: [{ diaryid: 'desc' }],
       },
     });
 

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -333,7 +333,7 @@ export class DiariesRepository extends Repository<Diary> {
       body: {
         _source: [
           'authorname',
-          'diaryid',
+          'diaryId',
           'thumbnail',
           'title',
           'summary',
@@ -349,7 +349,7 @@ export class DiariesRepository extends Repository<Diary> {
         query: {
           bool: {
             must: [
-              { term: { authorid: userId } },
+              { term: { authorid: 15 } },
               {
                 multi_match: {
                   query: keyword,
@@ -359,7 +359,7 @@ export class DiariesRepository extends Repository<Diary> {
             ],
           },
         },
-        sort: [{ diaryid: 'desc' }],
+        sort: [{ diaryId: 'desc' }],
       },
     });
 

--- a/backend/src/diaries/diaries.repository.ts
+++ b/backend/src/diaries/diaries.repository.ts
@@ -12,12 +12,15 @@ import {
   SearchDiaryDataForm,
 } from './dto/diary.dto';
 import { startOfDay, endOfDay } from 'date-fns';
+import Redis from 'ioredis';
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
 
 @Injectable()
 export class DiariesRepository extends Repository<Diary> {
   constructor(
     private dataSource: DataSource,
     private readonly elasticsearchService: ElasticsearchService,
+    @InjectRedis() private readonly redis: Redis,
   ) {
     super(Diary, dataSource.createEntityManager());
   }
@@ -402,6 +405,10 @@ export class DiariesRepository extends Repository<Diary> {
     });
 
     return diaries;
+  }
+
+  async addDiaryEvent(diaryId: number): Promise<void> {
+    this.redis.publish('diary.event', JSON.stringify({ diaryId }));
   }
 
   private mapToLeaveReaction(diaryInfo, userId: number) {

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -222,7 +222,7 @@ export class DiariesService {
       );
 
       return {
-        diaryId: diary.diaryid,
+        diaryId: diary.diaryId,
         thumbnail: diary.thumbnail,
         title: diary.title,
         summary: diary.summary,

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -217,7 +217,7 @@ export class DiariesService {
       );
 
       return {
-        diaryId: diary.diaryId,
+        diaryId: diary.diaryid,
         thumbnail: diary.thumbnail,
         title: diary.title,
         summary: diary.summary,

--- a/backend/src/diaries/diaries.service.ts
+++ b/backend/src/diaries/diaries.service.ts
@@ -95,20 +95,15 @@ export class DiariesService {
       existingDiary.mood = await this.judgeOverallMood(plainText);
     }
 
-    await Promise.all([
-      this.diariesRepository.save(existingDiary),
-      this.diariesRepository.addDiaryEvent(diaryId),
-    ]);
+    await this.diariesRepository.save(existingDiary);
+    await this.diariesRepository.addDiaryEvent(diaryId);
   }
 
   async deleteDiary(user: User, diaryId: number) {
     await this.findDiary(user, diaryId);
 
-    //TODO: 다이어리 저장이 실패하면, 이벤트를 발생시키지 않도록 변경 + softDelete에서 user와 diaryId를 검사하도록 변경
-    await Promise.all([
-      await this.diariesRepository.softDelete(diaryId),
-      await this.diariesRepository.addDiaryEvent(diaryId),
-    ]);
+    await this.diariesRepository.softDelete(diaryId);
+    await this.diariesRepository.addDiaryEvent(diaryId);
   }
 
   async findAllDiaryEmotions(

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -222,7 +222,7 @@ export class GetYearMoodResponseDto {
 
 export class SearchDiaryDataForm {
   authorname: string;
-  diaryId: number;
+  diaryid: number;
   thumbnail: string;
   title: string;
   summary: string;

--- a/backend/src/diaries/dto/diary.dto.ts
+++ b/backend/src/diaries/dto/diary.dto.ts
@@ -222,7 +222,7 @@ export class GetYearMoodResponseDto {
 
 export class SearchDiaryDataForm {
   authorname: string;
-  diaryid: number;
+  diaryId: number;
   thumbnail: string;
   title: string;
   summary: string;

--- a/backend/src/reactions/reactions.repository.ts
+++ b/backend/src/reactions/reactions.repository.ts
@@ -4,10 +4,15 @@ import { Reaction } from './entity/reaction.entity';
 import { Diary } from 'src/diaries/entity/diary.entity';
 import { User } from 'src/users/entity/user.entity';
 import { ReactionInfoResponseDto } from './dto/reaction.dto';
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import Redis from 'ioredis';
 
 @Injectable()
 export class ReactionsRepository extends Repository<Reaction> {
-  constructor(private dataSource: DataSource) {
+  constructor(
+    private dataSource: DataSource,
+    @InjectRedis() private readonly redis: Redis,
+  ) {
     super(Reaction, dataSource.createEntityManager());
   }
 
@@ -41,5 +46,9 @@ export class ReactionsRepository extends Repository<Reaction> {
       .where('reaction.diaryId = :diaryId', { diaryId })
       .innerJoin('reaction.user', 'user')
       .getRawMany();
+  }
+
+  async addDiaryEvent(diaryId: number): Promise<void> {
+    this.redis.publish('diary.event', JSON.stringify({ diaryId }));
   }
 }

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -27,10 +27,8 @@ export class ReactionsService {
       throw new BadRequestException('이미 저장된 리액션 정보입니다.');
     }
 
-    await Promise.all([
-      this.reactionsRepository.save({ user, diary, reaction: reactionRequestDto.reaction }),
-      this.reactionsRepository.addDiaryEvent(diary.id),
-    ]);
+    await this.reactionsRepository.save({ user, diary, reaction: reactionRequestDto.reaction });
+    await this.reactionsRepository.addDiaryEvent(diary.id);
   }
 
   async updateReaction(user: User, diaryId: number, reactionRequestDto: ReactionRequestDto) {
@@ -42,10 +40,8 @@ export class ReactionsService {
     }
 
     reaction.reaction = reactionRequestDto.reaction;
-    await Promise.all([
-      this.reactionsRepository.save(reaction),
-      this.reactionsRepository.addDiaryEvent(diary.id),
-    ]);
+    await this.reactionsRepository.save(reaction);
+    await this.reactionsRepository.addDiaryEvent(diary.id);
   }
 
   async deleteReaction(user: User, diaryId: number, reactionRequestDto: ReactionRequestDto) {
@@ -60,9 +56,7 @@ export class ReactionsService {
       throw new BadRequestException('이미 삭제된 리액션 정보입니다.');
     }
 
-    await Promise.all([
-      this.reactionsRepository.remove(reaction),
-      this.reactionsRepository.addDiaryEvent(diary.id),
-    ]);
+    await this.reactionsRepository.remove(reaction);
+    await this.reactionsRepository.addDiaryEvent(diary.id);
   }
 }

--- a/backend/src/reactions/reactions.service.ts
+++ b/backend/src/reactions/reactions.service.ts
@@ -27,7 +27,10 @@ export class ReactionsService {
       throw new BadRequestException('이미 저장된 리액션 정보입니다.');
     }
 
-    this.reactionsRepository.save({ user, diary, reaction: reactionRequestDto.reaction });
+    await Promise.all([
+      this.reactionsRepository.save({ user, diary, reaction: reactionRequestDto.reaction }),
+      this.reactionsRepository.addDiaryEvent(diary.id),
+    ]);
   }
 
   async updateReaction(user: User, diaryId: number, reactionRequestDto: ReactionRequestDto) {
@@ -39,7 +42,10 @@ export class ReactionsService {
     }
 
     reaction.reaction = reactionRequestDto.reaction;
-    await this.reactionsRepository.save(reaction);
+    await Promise.all([
+      this.reactionsRepository.save(reaction),
+      this.reactionsRepository.addDiaryEvent(diary.id),
+    ]);
   }
 
   async deleteReaction(user: User, diaryId: number, reactionRequestDto: ReactionRequestDto) {
@@ -54,6 +60,9 @@ export class ReactionsService {
       throw new BadRequestException('이미 삭제된 리액션 정보입니다.');
     }
 
-    this.reactionsRepository.remove(reaction);
+    await Promise.all([
+      this.reactionsRepository.remove(reaction),
+      this.reactionsRepository.addDiaryEvent(diary.id),
+    ]);
   }
 }


### PR DESCRIPTION
## 이슈 번호

#305 

## 완료한 기능 명세

- [x] 엘라스틱서치와 DB 동기화 방식 변경

---

```
input {
  redis {
    host => 
    port => 
    password => 
    data_type => "channel"
    key => "diary.event"
  }
}

filter {
  json {
    source => "message"
    target => "diary_data"
  }

  jdbc_streaming {
    jdbc_driver_library => 
    jdbc_driver_class => 
    jdbc_connection_string => 
    jdbc_user => 
    jdbc_password => 
    statement => "
      SELECT
        diary.id AS diaryid,
        diary.title AS title,
        diary.content AS content,
        diary.summary AS summary,
        diary.thumbnail AS thumbnail,
        diary.emotion AS emotion,
        diary.mood AS mood,
        diary.status AS status,
        diary.createdAt AS createdat,
        diary.updatedAt AS updatedat,
        diary.deletedAt AS deletedAt,
        GROUP_CONCAT(tag.name) AS tagnames,
        GROUP_CONCAT(CONCAT(reaction.userId, ':', reaction.reaction)) AS reactions,
        user.id AS authorid,
        user.nickname AS authorname
      FROM diary
      LEFT JOIN diary_tag ON diary.id = diary_tag.diary_id
      LEFT JOIN tag ON diary_tag.tag_id = tag.id
      LEFT JOIN reaction ON diary.id = reaction.diaryId
      LEFT JOIN user ON diary.authorId = user.id
      WHERE diary.id = :diaryId
      GROUP BY diary.id"
    parameters => { diaryId => "[diaryId]" }
    target => "diary"
  }

  ...
}
```

기존에 1~2초 간격으로 모든 DB 데이터를 엘라스틱서치로 가져와서 새로운 데이터를 갱신하는 방법 대신 새로운 방식으로 구현했습니다.
새로운 방식에서는 일기 CRU + 리액션 CRU 시점에 redis 큐에 이벤트를 pub 하고, 해당 이벤트를 logstash에서 consume해 ID를 조회하고 해당 데이터만 가져와 갱신하도록 구현해 놓았습니다.
추가적으로 redis가 데이터가 들어오는 순서를 보장하는지, 전송 과정에서 실패를 어떻게 처리하는지(exactly once 등), 실패 시 처리를 어떻게 해야할지 고민해 봐야할 것 같습니다.

![image](https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/3a8ee7b1-c30b-476b-a086-a27f54d91655)

postman에서는 잘 들어오는 것 같은데, 설정 파일을 싹 갈아엎어서 배포 해보고 버그가 발생하는지 확인은 해봐야 할 것 같습니다.
