### PR TITLE
[FE] Home API 요청 최적화

### DIFF
--- a/frontend/src/components/Common/DiaryListItem.tsx
+++ b/frontend/src/components/Common/DiaryListItem.tsx
@@ -1,12 +1,11 @@
-import { useState, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import EmojiPicker from 'emoji-picker-react';
 
-import { getReactionList, postReaction, deleteReaction } from '@api/Reaction';
+import { postReaction, deleteReaction } from '@api/Reaction';
 
 import { IDiaryContent } from '@type/components/Common/DiaryList';
-import { IReactionedFriends } from '@type/components/Common/ReactionList';
 
 import Reaction from '@components/Common/Reaction';
 import ProfileItem from '@components/Common/ProfileItem';
@@ -27,27 +26,8 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
   const navigate = useNavigate();
   const [showModal, setShowModal] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
-  const [selectedEmoji, setSelectedEmoji] = useState('');
+  const [selectedEmoji, setSelectedEmoji] = useState<string>(diaryItem.leavedReaction);
   const [totalReaction, setTotalReaction] = useState(diaryItem.reactionCount);
-  const { data, isError, isSuccess } = useQuery({
-    queryKey: ['reactionList', diaryItem.diaryId],
-    queryFn: () => getReactionList(Number(diaryItem.diaryId)),
-  });
-
-  if (isError) {
-    return <p>Error fetching data</p>;
-  }
-
-  useEffect(() => {
-    if (isSuccess) {
-      const loginUserId = localStorage.getItem('userId') ?? 0;
-      const myData = data.reactionList.find(
-        (item: IReactionedFriends) => item.userId === +loginUserId,
-      );
-      myData && setSelectedEmoji(myData?.reaction);
-      setTotalReaction(data.reactionList.length);
-    }
-  }, [isSuccess]);
 
   const postReactionMutation = useMutation({
     mutationFn: () => postReaction(Number(diaryItem.diaryId), selectedEmoji),
@@ -69,15 +49,15 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
     },
   });
 
-  const handleDeleteReaction = async () => {
-    await deleteReactionMutation.mutate();
-    setTotalReaction(totalReaction - 1);
+  const handleDeleteReaction = () => {
+    deleteReactionMutation.mutate();
     setSelectedEmoji('');
+    setTotalReaction((prev) => prev - 1);
   };
 
   const toggleShowModal = () => setShowModal((prev) => !prev);
   const toggleShowEmojiPicker = () => {
-    if (selectedEmoji === '') {
+    if (!selectedEmoji) {
       setShowEmojiPicker((prev) => !prev);
     } else {
       handleDeleteReaction();
@@ -87,11 +67,11 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
   const goDetail = () => navigate(`${PAGE_URL.DETAIL}/${diaryItem.diaryId}`);
   const goFriendHome = () => navigate(`${PAGE_URL.HOME}${diaryItem.authorId}`);
 
-  const onClickEmoji = async (emojiData: any) => {
+  const onClickEmoji = (emojiData: any) => {
+    postReactionMutation.mutate();
     setSelectedEmoji(emojiData.emoji);
-    await postReactionMutation.mutate();
-    setTotalReaction(totalReaction + 1);
     toggleShowEmojiPicker();
+    setTotalReaction((prev) => prev + 1);
   };
 
   return (

--- a/frontend/src/components/Home/EmotionStat.tsx
+++ b/frontend/src/components/Home/EmotionStat.tsx
@@ -45,9 +45,10 @@ const EmotionStat = ({ nickname }: EmotionStatProps) => {
   }, [state?.startDate, state?.endDate]);
 
   const { data, isError, isLoading } = useQuery({
-    queryKey: ['emotionStat', userId, period],
+    queryKey: ['emotionStat', userId, formatDateDash(period[0]), formatDateDash(period[1])],
     queryFn: () =>
       getEmotionStat(Number(userId), formatDateDash(period[0]), formatDateDash(period[1])),
+    staleTime: Infinity,
   });
 
   const navigatedURL = `${params.userId ? `/${params.userId}` : PAGE_URL.HOME}`;
@@ -67,7 +68,7 @@ const EmotionStat = ({ nickname }: EmotionStatProps) => {
   const eData = (data?.emotions || []).map((item: emotionCloudProps) => {
     return {
       text: item.emotion,
-      size: Math.log(item.diaryInfo.length + 1) / Math.log(totalLength + 1) * 100,
+      size: (Math.log(item.diaryInfo.length + 1) / Math.log(totalLength + 1)) * 100,
     };
   });
   return (

--- a/frontend/src/components/Home/Grass.tsx
+++ b/frontend/src/components/Home/Grass.tsx
@@ -33,6 +33,7 @@ const Grass = () => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['grass', userId],
     queryFn: () => getGrass(Number(userId)),
+    staleTime: Infinity,
   });
 
   if (isLoading) {

--- a/frontend/src/components/MyDiary/Card.tsx
+++ b/frontend/src/components/MyDiary/Card.tsx
@@ -1,12 +1,11 @@
-import { useState, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import EmojiPicker from 'emoji-picker-react';
 
-import { getReactionList, postReaction, deleteReaction } from '@api/Reaction';
+import { postReaction, deleteReaction } from '@api/Reaction';
 
 import { IDiaryContent } from '@type/components/Common/DiaryList';
-import { IReactionedFriends } from '@type/components/Common/ReactionList';
 
 import Keyword from '@components/Common/Keyword';
 import Reaction from '@components/Common/Reaction';
@@ -25,31 +24,10 @@ interface CardProps {
 const Card = ({ diaryItem, styles, size }: CardProps) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const params = useParams();
-  const userId = params.userId ? params.userId : localStorage.getItem('userId');
   const [showModal, setShowModal] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
-  const [selectedEmoji, setSelectedEmoji] = useState('');
+  const [selectedEmoji, setSelectedEmoji] = useState(diaryItem.leavedReaction);
   const [totalReaction, setTotalReaction] = useState(diaryItem.reactionCount);
-
-  const { data, isError, isSuccess } = useQuery({
-    queryKey: ['reactionList', diaryItem.diaryId],
-    queryFn: () => getReactionList(Number(diaryItem.diaryId)),
-  });
-
-  if (isError) {
-    return <p>Error fetching data</p>;
-  }
-
-  useEffect(() => {
-    if (isSuccess) {
-      const myData = data.reactionList.find(
-        (item: IReactionedFriends) => item.userId === Number(userId),
-      );
-      myData && setSelectedEmoji(myData?.reaction);
-      setTotalReaction(data.reactionList.length);
-    }
-  }, [isSuccess]);
 
   const postReactionMutation = useMutation({
     mutationFn: () => postReaction(Number(diaryItem.diaryId), selectedEmoji),
@@ -78,7 +56,7 @@ const Card = ({ diaryItem, styles, size }: CardProps) => {
   };
   const toggleShowModal = () => setShowModal((prev) => !prev);
   const toggleShowEmojiPicker = () => {
-    if (selectedEmoji === '') {
+    if (!selectedEmoji) {
       setShowEmojiPicker((prev) => !prev);
     } else {
       handleDeleteReaction();

--- a/frontend/src/components/MyDiary/MonthContainer.tsx
+++ b/frontend/src/components/MyDiary/MonthContainer.tsx
@@ -21,7 +21,7 @@ const MonthContainer = () => {
   const last = new Date(nowMonth.getFullYear(), nowMonth.getMonth() + NEXT_INDEX, 0);
 
   const { data } = useQuery({
-    queryKey: ['monthDiaryData', localStorage.getItem('userId'), nowMonth],
+    queryKey: ['monthDiaryData', localStorage.getItem('userId'), formatDateDash(nowMonth)],
     queryFn: () =>
       getDiaryWeekAndMonthList({
         userId: localStorage.getItem('userId') as string,

--- a/frontend/src/components/MyDiary/WeekContainer.tsx
+++ b/frontend/src/components/MyDiary/WeekContainer.tsx
@@ -28,7 +28,12 @@ const WeekContainer = () => {
   const [period, setPeriod] = useState(calPeriod());
 
   const { data } = useQuery<{ nickname: string; diaryList: IDiaryContent[] }>({
-    queryKey: ['myWeekDiary', localStorage.getItem('userId'), period[0], period[1]],
+    queryKey: [
+      'myWeekDiary',
+      localStorage.getItem('userId'),
+      formatDateDash(period[0]),
+      formatDateDash(period[1]),
+    ],
     queryFn: () =>
       getDiaryWeekAndMonthList({
         userId: localStorage.getItem('userId') as string,

--- a/frontend/src/pages/Detail.tsx
+++ b/frontend/src/pages/Detail.tsx
@@ -32,11 +32,11 @@ const Detail = () => {
   const deleteDiaryMutation = useMutation({
     mutationFn: () => deleteDiary(diaryId),
     onSuccess: () => {
-      queryClient.removeQueries({
-        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+      queryClient.invalidateQueries({
+        queryKey: ['grass', localStorage.getItem('userId')],
       });
-      queryClient.removeQueries({
-        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
+      queryClient.invalidateQueries({
+        queryKey: ['emotionStat', localStorage.getItem('userId')],
       });
       navigate(-1);
       openToast('일기가 삭제되었습니다!');

--- a/frontend/src/pages/Edit.tsx
+++ b/frontend/src/pages/Edit.tsx
@@ -51,11 +51,11 @@ const Edit = () => {
     mutationFn: (params: CreateDiaryParams) => createDiary(params),
     onSuccess: () => {
       navigate(PAGE_URL.MY_DIARY);
-      queryClient.removeQueries({
-        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+      queryClient.invalidateQueries({
+        queryKey: ['grass', localStorage.getItem('userId')],
       });
-      queryClient.removeQueries({
-        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
+      queryClient.invalidateQueries({
+        queryKey: ['emotionStat', localStorage.getItem('userId')],
       });
       openToast('일기가 작성되었습니다!');
     },
@@ -65,11 +65,11 @@ const Edit = () => {
     mutationFn: (params: CreateDiaryParams) => updateDiary(params, state.diaryId),
     onSuccess: () => {
       navigate(`${PAGE_URL.DETAIL}/${state.diaryId}`);
-      queryClient.removeQueries({
-        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+      queryClient.invalidateQueries({
+        queryKey: ['grass', localStorage.getItem('userId')],
       });
-      queryClient.removeQueries({
-        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
+      queryClient.invalidateQueries({
+        queryKey: ['emotionStat', localStorage.getItem('userId')],
       });
       openToast('일기가 수정되었습니다!');
     },

--- a/frontend/src/types/components/Common/DiaryList.ts
+++ b/frontend/src/types/components/Common/DiaryList.ts
@@ -13,6 +13,7 @@ export interface IDiaryContent {
   reactionCount: number;
   authorId?: string | number;
   diaryId: string | number;
+  leavedReaction: string;
 }
 
 export interface InfiniteDiaryListProps {


### PR DESCRIPTION
## 이슈 번호
#330 

## 완료한 기능 명세
- DiaryListItem에서 ReactionList 데이터에 의존되있던 코드를 제거하고 Props로 받아온 데이터를 사용하는 방식으로 변경하였습니다.
- 잔디와 감정통계 데이터를 받아오는 쿼리의 상태를 Fresh로 변경하여 다시 마운트될 때 캐싱된 값을 사용하고  일기 저장, 수정, 삭제
되었을 때  해당 쿼리를 무효화해 다시 데이터를 받아오는 방식으로 변경하였습니다.

### 개선 전
<img width="800" alt="개선 전" src="https://github.com/boostcampwm2023/web18_Dandi/assets/81965433/9813a8aa-b239-44ce-99f1-055291fd30bd">

### 개선 후
<img width="800" alt="개선 후" src="https://github.com/boostcampwm2023/web18_Dandi/assets/81965433/d23c7455-7ea5-4343-85db-a5736af42bf8">
