### PR TITLE
[FE] Modal div 여러 개 생기는 오류 해결

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link
       href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT/fonts/variable/woff2/SUIT-Variable.css"
-      rel="preload"
+      rel="preload" as="style"
     />
     <link rel="apple-touch-icon-precomposed" sizes="57x57" href="apple-touch-icon-57x57.png" />
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="apple-touch-icon-114x114.png" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import Router from './Router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import { ToastProvider } from '@util/ToastProvider';
 import ModalProvider from '@util/ModalProvider';
 

--- a/frontend/src/components/Common/DiaryListItem.tsx
+++ b/frontend/src/components/Common/DiaryListItem.tsx
@@ -9,7 +9,6 @@ import { IDiaryContent } from '@type/components/Common/DiaryList';
 
 import Reaction from '@components/Common/Reaction';
 import ProfileItem from '@components/Common/ProfileItem';
-import Modal from '@components/Common/Modal';
 import ReactionList from '@components/Diary/ReactionList';
 import Keyword from '@components/Common/Keyword';
 
@@ -28,7 +27,7 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [selectedEmoji, setSelectedEmoji] = useState<string>('');
   const [totalReaction, setTotalReaction] = useState(0);
-  const { openModal } = useModal();
+  const { isOpen, openModal } = useModal();
 
   useEffect(() => {
     setSelectedEmoji(diaryItem.leavedReaction);
@@ -109,11 +108,13 @@ const DiaryListItem = ({ pageType, diaryItem }: DiaryListItemProps) => {
         count={totalReaction}
         iconOnClick={toggleShowEmojiPicker}
         textOnClick={() =>
-          openModal({ children: <ReactionList diaryId={Number(diaryItem.diaryId)} /> })
+          !isOpen &&
+          openModal({
+            children: <ReactionList diaryId={Number(diaryItem.diaryId)} />,
+          })
         }
         emoji={selectedEmoji}
       />
-      <Modal />
       {showEmojiPicker && (
         <aside className="absolute bottom-14 z-50">
           <EmojiPicker onEmojiClick={onClickEmoji} />

--- a/frontend/src/components/Common/Modal.tsx
+++ b/frontend/src/components/Common/Modal.tsx
@@ -7,11 +7,11 @@ import useModal from '@hooks/useModal';
 const Modal = () => {
   const { isOpen, modalData, closeModal } = useModal();
 
+  const { children } = modalData;
+
   if (!isOpen) {
     return <></>;
   }
-
-  const { children } = modalData;
 
   const onClickModalBack = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (e.target === e.currentTarget) closeModal();
@@ -20,7 +20,7 @@ const Modal = () => {
   return createPortal(
     <>
       <div
-        className="fixed left-0 top-0 z-40 flex h-full w-full items-center justify-center bg-white bg-opacity-20"
+        className="fixed left-0 top-0 z-40 flex h-full w-full items-center justify-center bg-white bg-opacity-70"
         onClick={onClickModalBack}
       >
         <div className="border-default relative h-auto max-h-[75%] w-1/3 min-w-[90%] overflow-hidden rounded-2xl border bg-white p-4 pb-5 shadow-[0_0_10px_0_rgba(0,0,0,0.1)] sm:min-w-min">

--- a/frontend/src/components/Detail/DiaryContent.tsx
+++ b/frontend/src/components/Detail/DiaryContent.tsx
@@ -6,7 +6,6 @@ import { getReactionList, postReaction, deleteReaction } from '@api/Reaction';
 import { IReactionedFriends } from '@type/components/Common/ReactionList';
 import ProfileItem from '@components/Common/ProfileItem';
 import Reaction from '@components/Common/Reaction';
-import Modal from '@components/Common/Modal';
 import Keyword from '@components/Common/Keyword';
 import ReactionList from '@components/Diary/ReactionList';
 
@@ -115,7 +114,6 @@ const DiaryContent = ({
           iconOnClick={toggleShowEmojiPicker}
           emoji={selectedEmoji}
         />
-        <Modal />
         {showEmojiPicker && (
           <aside className="absolute bottom-14 z-50">
             <EmojiPicker onEmojiClick={onClickEmoji} />

--- a/frontend/src/components/Home/Profile.tsx
+++ b/frontend/src/components/Home/Profile.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteFriend, requestFriend } from '@api/FriendModal';
 
 import Button from '@components/Common/Button';
-import Modal from '@components/Common/Modal';
 import FriendList from '@components/Home/FriendList';
 import FriendRequest from '@components/Home/FriendRequest';
 import ProfileEdit from '@components/Home/ProfileEdit';
@@ -204,8 +203,6 @@ const Profile = ({ userId, userData }: ProfileProps) => {
           />
         </div>
       )}
-
-      <Modal />
     </section>
   );
 };

--- a/frontend/src/components/MyDiary/Card.tsx
+++ b/frontend/src/components/MyDiary/Card.tsx
@@ -10,7 +10,6 @@ import { IDiaryContent } from '@type/components/Common/DiaryList';
 import Keyword from '@components/Common/Keyword';
 import Reaction from '@components/Common/Reaction';
 import ReactionList from '@components/Diary/ReactionList';
-import Modal from '@components/Common/Modal';
 
 import { formatDateString } from '@util/funcs';
 import { PAGE_URL, SMALL } from '@util/constants';
@@ -101,7 +100,6 @@ const Card = ({ diaryItem, styles, size }: CardProps) => {
         emoji={selectedEmoji}
         styles={`${size === SMALL ? 'text-sm' : ''}`}
       />
-      <Modal />
       {showEmojiPicker && (
         <aside className="absolute left-14 top-1/3 z-50">
           <EmojiPicker onEmojiClick={onClickEmoji} />

--- a/frontend/src/pages/Detail.tsx
+++ b/frontend/src/pages/Detail.tsx
@@ -75,35 +75,37 @@ const Detail = () => {
   const loginUser = localStorage.getItem('userId') ?? 0;
   const isMyDiary = +loginUser === data.userId;
   return (
-    <div className="flex flex-col items-center">
-      <NavBar />
-      <div className="mt-5 flex w-full flex-col gap-4 p-1 sm:w-2/3 sm:p-0">
-        {content}
-        {isMyDiary && (
-          <div className="mb-20 flex justify-around">
-            <Button
-              text="수정"
-              type="normal"
-              onClick={() =>
-                navigate(PAGE_URL.EDIT, {
-                  state: {
-                    diaryId: diaryId,
-                    title: data.title,
-                    content: data.content,
-                    emotion: data.emotion,
-                    thumbnail: data.thumbnail,
-                    tagNames: data.tagNames,
-                    status: data.status,
-                  },
-                })
-              }
-            />
-            <Button text="삭제" type="delete" onClick={showDeleteModal} />
-            <Modal />
-          </div>
-        )}
+    <>
+      <div className="flex flex-col items-center">
+        <NavBar />
+        <div className="mt-5 flex w-full flex-col gap-4 p-1 sm:w-2/3 sm:p-0">
+          {content}
+          {isMyDiary && (
+            <div className="mb-20 flex justify-around">
+              <Button
+                text="수정"
+                type="normal"
+                onClick={() =>
+                  navigate(PAGE_URL.EDIT, {
+                    state: {
+                      diaryId: diaryId,
+                      title: data.title,
+                      content: data.content,
+                      emotion: data.emotion,
+                      thumbnail: data.thumbnail,
+                      tagNames: data.tagNames,
+                      status: data.status,
+                    },
+                  })
+                }
+              />
+              <Button text="삭제" type="delete" onClick={showDeleteModal} />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+      <Modal />
+    </>
   );
 };
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import { viewTypes } from '@type/pages/MyDiary';
 import NavBar from '@components/Common/NavBar';
 import Loading from '@components/Common/Loading';
 import DiaryListItem from '@components/Common/DiaryListItem';
+import Modal from '@components/Common/Modal';
 import Profile from '@components/Home/Profile';
 import Grass from '@components/Home/Grass';
 import EmotionStat from '@components/Home/EmotionStat';
@@ -89,28 +90,31 @@ const Home = () => {
   const isEmpty = !diaryData?.pages[0].diaryList.length;
 
   return (
-    <main className="mb-12 flex flex-col items-center justify-start">
-      <NavBar />
-      <Profile userId={userId ? +userId : 0} userData={profileData} />
-      <Grass />
-      <EmotionStat nickname={profileData.nickname} />
+    <>
+      <main className="mb-12 flex flex-col items-center justify-start">
+        <NavBar />
+        <Profile userId={userId ? +userId : 0} userData={profileData} />
+        <Grass />
+        <EmotionStat nickname={profileData.nickname} />
 
-      <div className="w-full p-5 sm:w-3/5">
-        <h1 className="mb-5 text-lg font-bold sm:text-2xl">{`${profileData.nickname}${PAGE_TITLE_HOME}`}</h1>
-        {isEmpty && (
-          <div className="mt-20 flex w-full flex-col items-center justify-center gap-3">
-            <img className="w-1/3" src={dizzyFace} alt="작성한 일기가 없는 그림" />
-            <p className="text-xl font-bold">작성한 일기가 없어요.</p>
-          </div>
-        )}
-        {diaryData?.pages.map((page, pageIndex) =>
-          page.diaryList.map((item, itemIndex) => (
-            <DiaryListItem diaryItem={item} key={Number(String(pageIndex) + String(itemIndex))} />
-          )),
-        )}
-      </div>
-      <div ref={infiniteRef} />
-    </main>
+        <div className="w-full p-5 sm:w-3/5">
+          <h1 className="mb-5 text-lg font-bold sm:text-2xl">{`${profileData.nickname}${PAGE_TITLE_HOME}`}</h1>
+          {isEmpty && (
+            <div className="mt-20 flex w-full flex-col items-center justify-center gap-3">
+              <img className="w-1/3" src={dizzyFace} alt="작성한 일기가 없는 그림" />
+              <p className="text-xl font-bold">작성한 일기가 없어요.</p>
+            </div>
+          )}
+          {diaryData?.pages.map((page, pageIndex) =>
+            page.diaryList.map((item, itemIndex) => (
+              <DiaryListItem diaryItem={item} key={Number(String(pageIndex) + String(itemIndex))} />
+            )),
+          )}
+        </div>
+        <div ref={infiniteRef} />
+      </main>
+      <Modal />
+    </>
   );
 };
 

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -10,6 +10,7 @@ import { InfiniteDiaryListProps } from '@type/components/Common/DiaryList';
 
 import NavBar from '@components/Common/NavBar';
 import DiaryListItem from '@components/Common/DiaryListItem';
+import Modal from '@components/Common/Modal';
 import KeywordSearch from '@components/MyDiary/KeywordSearch';
 import WeekContainer from '@components/MyDiary/WeekContainer';
 import ViewType from '@components/MyDiary/ViewType';
@@ -168,6 +169,7 @@ const MyDiary = () => {
         {viewType === DIARY_VIEW_TYPE.WEEK && <WeekContainer />}
         {viewType === DIARY_VIEW_TYPE.MONTH && <MonthContainer />}
       </main>
+      <Modal />
     </>
   );
 };

--- a/frontend/src/util/ModalProvider.tsx
+++ b/frontend/src/util/ModalProvider.tsx
@@ -17,16 +17,21 @@ const ModalProvider = ({ children }: { children: React.ReactNode }) => {
 
   const openModal = ({ children }: ModalData) => {
     setIsOpen(true);
+    document.body.style.cssText = `
+    position: fixed; 
+    top: -${window.scrollY}px;
+    overflow-y: scroll;
+    width: 100%;`;
     setModalData({ children });
-    document.body.style.overflow = 'hidden';
   };
 
   const closeModal = () => {
     setIsOpen(false);
     setModalData({});
-    document.body.style.overflow = 'auto';
+    const scrollY = document.body.style.top;
+    document.body.style.cssText = '';
+    window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
   };
-
   return (
     <ModalContext.Provider value={{ isOpen, openModal, closeModal, modalData }}>
       {children}


### PR DESCRIPTION
## 이슈 번호
#347

## 완료한 기능 명세
<img width="1503" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/f4798c76-7273-4d27-bc2e-53d2493d5f0e">
- Modal div 여러 개 생기는 오류 해결
  - 하위 컴포넌트가 아닌 부모 컴포넌트에서 Modal을 한 번만 불러오게 하여 해결
- Modal 켜져있을 시 스크롤이 되지 않되, 스크롤바는 사라지지 않도록 수정
- index.html의 SUIT-Variable.css link에 as="style" 속성 추가