### PR TITLE
[FE] 페이지 이동 시 모달이 닫히지 않는 문제 해결

### DIFF
--- a/frontend/src/pages/Detail.tsx
+++ b/frontend/src/pages/Detail.tsx
@@ -48,7 +48,7 @@ const Detail = () => {
 
   const handleDelete = () => {
     deleteDiaryMutation.mutate();
-    showDeleteModal();
+    closeModal();
   };
 
   const showDeleteModal = () => {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -20,11 +20,17 @@ import EmotionStat from '@components/Home/EmotionStat';
 
 import { PAGE_TITLE_HOME, PAGE_URL } from '@util/constants';
 
+import useModal from '@hooks/useModal';
+
 const Home = () => {
   const params = useParams();
   const userId = params.userId ? params.userId : localStorage.getItem('userId');
   const infiniteRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+  const { closeModal } = useModal();
+  useEffect(() => {
+    closeModal();
+  }, [userId]);
 
   const {
     data: profileData,


### PR DESCRIPTION
## 이슈 번호
#351

## 완료한 기능 명세

https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/e3d1579a-0c90-40bf-af8a-7770fc0d3f52

- 일기 삭제 시 모달 닫히도록 closeModal 함수 실행
- Home에서 userId가 바뀌었을 때 closeModal 함수 실행