### PR TITLE
[BE] 10MB 파일까지 입력 받을 수 있도록 변경

### DIFF
--- a/nginx/dandi-blue.conf
+++ b/nginx/dandi-blue.conf
@@ -9,6 +9,8 @@ server {
   index  index.html;
 
   location /api {
+    client_max_body_size 10m;
+    
     proxy_pass http://was-blue; # WAS로 이동
     proxy_redirect     off;
     proxy_set_header Host $http_host;

--- a/nginx/dandi-green.conf
+++ b/nginx/dandi-green.conf
@@ -9,6 +9,8 @@ server {
   index  index.html;
 
   location /api {
+    client_max_body_size 10m;
+    
     proxy_pass http://was-green; # WAS로 이동
     proxy_redirect     off;
     proxy_set_header Host $http_host;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,6 +29,8 @@ server {
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # 보안 강화
 
   location / {
+    client_max_body_size 10M;
+
     proxy_pass http://frontend-blue; # 웹서버로 이동
     proxy_redirect     off;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
## 이슈 번호

#358 

## 완료한 기능 명세

<img width="494" alt="image" src="https://github.com/boostcampwm2023/web18_Dandi/assets/75190035/2af209da-9f9b-4c1d-8dd8-2237dd00e0e1">

- 10MB 파일이 로컬에서는 잘 들어가는 상황이라 네트워크를 확인하니 서버가 아닌 NGINX에서 413 에러를 반환하고 있었습니다.
- 때문에 모든 NGINX 설정 파일에 `client_max_body_size`를 추가했습니다.
- 로컬에서는 테스트가 불가해서 머지 해보고 테스트해야할 것 같습니다...
