### PR TITLE
[FE] 날짜 관련 오류 & 상세페이지에 이모지가 제대로 반영되지 않는 문제 해결

### DIFF
--- a/frontend/src/components/Detail/DiaryContent.tsx
+++ b/frontend/src/components/Detail/DiaryContent.tsx
@@ -85,7 +85,7 @@ const DiaryContent = ({
       const myData = data.reactionList.find(
         (item: IReactionedFriends) => item.userId === +loginUserId,
       );
-      myData && setSelectedEmoji(myData?.reaction);
+      setSelectedEmoji(myData?.reaction);
       setTotalReaction(data.reactionList.length);
     }
   }, [data]);

--- a/frontend/src/util/funcs.ts
+++ b/frontend/src/util/funcs.ts
@@ -24,8 +24,7 @@ export const formatDate = (date: Date) => {
 };
 
 export const formatDateString = (str: string) => {
-  const DateObject = new Date(str);
-  const koreaTime = new Date(DateObject.toUTCString());
+  const koreaTime = getKorTime(str);
   const year = koreaTime.getFullYear();
   const month = koreaTime.getMonth() + 1;
   const day = koreaTime.getDate();
@@ -35,7 +34,7 @@ export const formatDateString = (str: string) => {
 };
 
 export const formatDateDash = (date: Date) => {
-  const koreaTime = new Date(date.toUTCString());
+  const koreaTime = new Date(date);
   const year = koreaTime.getFullYear();
   const month = (koreaTime.getMonth() + 1).toString().padStart(2, '0');
   const day = koreaTime.getDate().toString().padStart(2, '0');
@@ -44,7 +43,12 @@ export const formatDateDash = (date: Date) => {
 };
 
 export const calPrev = (date: Date, num: number) => {
-  const newDate = new Date(date.toUTCString());
+  const newDate = new Date(date);
   newDate.setDate(newDate.getDate() + num);
   return newDate;
+};
+
+const getKorTime = (date: string) => {
+  const utcDate = new Date(date);
+  return new Date(utcDate.getTime() + utcDate.getTimezoneOffset() * 60000);
 };


### PR DESCRIPTION
## 이슈 번호
#361 

## 완료한 기능 명세

https://github.com/boostcampwm2023/web18_Dandi/assets/97578425/016418b9-11e3-46a7-b656-b57f9be9b491

- API 응답으로 내려오는 date string이 UTC => 로컬 타임존과의 시차 구해서 반영
- myData(사용자가 누른 이모지)가 있을 경우에만 갱신 => 사용자가 누른 이모지가 없을 경우 갱신하지 못함
  - myData가 없어도 갱신할 수 있도록 수정