### PR TITLE
[FE] 상태관리 라이브러리 적용

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
-    "swiper": "^11.0.5"
+    "swiper": "^11.0.5",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@toast-ui/editor": "^3.2.2",

--- a/frontend/src/components/MyDiary/ViewType.tsx
+++ b/frontend/src/components/MyDiary/ViewType.tsx
@@ -1,13 +1,21 @@
+import { useNavigate } from 'react-router-dom';
 import { viewTypes } from '@type/pages/MyDiary';
+import useViewTypeStore from '@store/useViewTypeStore';
+import { DIARY_VIEW_TYPE_LIST, PAGE_URL } from '@util/constants';
 
-import { DIARY_VIEW_TYPE_LIST } from '@util/constants';
+const ViewType = () => {
+  const { viewType, setViewType } = useViewTypeStore();
+  const navigate = useNavigate();
 
-interface ViewTypeProp {
-  viewType: viewTypes;
-  handleViewTypeChange: (type: viewTypes) => void;
-}
+  const handleViewTypeChange = (type: viewTypes) => {
+    setViewType(type);
+    navigate(`${PAGE_URL.MY_DIARY}`, {
+      state: {
+        viewType: type,
+      },
+    });
+  };
 
-const ViewType = ({ viewType, handleViewTypeChange }: ViewTypeProp) => {
   return (
     <section className="flex justify-end gap-2 pr-5 sm:justify-center sm:pr-0">
       {DIARY_VIEW_TYPE_LIST.map((type, index) => (

--- a/frontend/src/pages/MyDiary.tsx
+++ b/frontend/src/pages/MyDiary.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { getDiaryDayList } from '@api/DiaryList';
@@ -17,13 +18,13 @@ import WeekContainer from '@components/MyDiary/WeekContainer';
 import ViewType from '@components/MyDiary/ViewType';
 import MonthContainer from '@components/MyDiary/MonthContainer';
 
-import { DIARY_VIEW_TYPE, PAGE_URL } from '@util/constants';
-import { useLocation, useNavigate } from 'react-router-dom';
+import useViewTypeStore from '@store/useViewTypeStore';
+
+import { DIARY_VIEW_TYPE } from '@util/constants';
 
 const MyDiary = () => {
-  const navigate = useNavigate();
   const { state } = useLocation();
-  const [viewType, setViewType] = useState<viewTypes>(state?.viewType || 'Day');
+  const { viewType, setViewType } = useViewTypeStore();
   const [keyword, setKeyword] = useState<string>('');
   const [searchFlag, setSearchFlag] = useState(false);
   const [selected, setSelected] = useState<searchOptionsType>('키워드');
@@ -59,15 +60,6 @@ const MyDiary = () => {
         : undefined;
     },
   });
-
-  const handleViewTypeChange = (type: viewTypes) => {
-    setViewType(type);
-    navigate(`${PAGE_URL.MY_DIARY}`, {
-      state: {
-        viewType: type,
-      },
-    });
-  };
 
   const {
     data: searchData,
@@ -117,12 +109,13 @@ const MyDiary = () => {
   }, [diaryDataSuccess, searchDataSuccess]);
 
   useEffect(() => {
-    if (state?.viewType && isViewTypes(state?.viewType)) {
-      setViewType(state?.viewType);
+    const newViewType = state?.viewType || 'Day';
+    if (isViewTypes(newViewType)) {
+      setViewType(newViewType);
     } else {
       setViewType('Day');
     }
-  }, [state?.viewType]);
+  }, [state]);
 
   const isEmpty = !diaryData?.pages[0].diaryList.length;
 
@@ -143,7 +136,7 @@ const MyDiary = () => {
             setSelected={setSelected}
             setSearchFlag={setSearchFlag}
           />
-          <ViewType handleViewTypeChange={handleViewTypeChange} viewType={viewType} />
+          <ViewType />
         </header>
         <section className="flex w-full flex-col items-center sm:w-3/5">
           {isEmpty && viewType === DIARY_VIEW_TYPE.DAY && (

--- a/frontend/src/store/useViewTypeStore.ts
+++ b/frontend/src/store/useViewTypeStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+import { viewTypes } from '@type/pages/MyDiary';
+
+interface viewTypeState {
+  viewType: viewTypes;
+  setViewType:(newViewType: viewTypes) => void;
+}
+
+const useViewTypeStore = create<viewTypeState>((set) => ({
+  viewType: 'Day',
+  setViewType: (newViewType) => set({ viewType: newViewType }),
+}));
+
+export default useViewTypeStore;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,8 +8,9 @@
       "@util/*": ["./src/util/*"],
       "@assets/*": ["./src/assets/*"],
       "@api/*": ["./src/api/*"],
-      "@type/*": ["src/types/*"],
-      "@hooks/*": ["src/hooks/*"]
+      "@type/*": ["./src/types/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@store/*": ["./src/store/*"]
     },
     "target": "ES2020",
     "useDefineForClassFields": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       '@api': resolve(__dirname, 'src/api'),
       '@type': resolve(__dirname, 'src/types'),
       '@hooks': resolve(__dirname, 'src/hooks'),
+      '@store': resolve(__dirname, 'src/store'),
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8987,6 +8987,11 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -9521,3 +9526,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.4.7:
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.4.7.tgz#355406be6b11ab335f59a66d2cf9815e8f24038c"
+  integrity sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
## 이슈 번호
#363

## 완료한 기능 명세
- Zustand 설치
- pages의 MyDiary와 하위 컴포넌트인 ViewType에서 공통으로 사용하는 viewType 상태를 store로 분리

## 특이사항
- 아직 라이브러리 사용법에 미숙하여 단순한걸 먼저 적용
- 현재 사용중인 상태들을 한눈에 알아볼 수 있도록 도식화를 해볼 것