### PR TITLE
[FE] Edit 페이지 상태 분리

### DIFF
--- a/frontend/src/components/Edit/Editor.tsx
+++ b/frontend/src/components/Edit/Editor.tsx
@@ -3,15 +3,11 @@ import { Editor as DiaryEditor } from '@toast-ui/react-editor';
 
 import { uploadImage } from '@api/Edit';
 
-interface EditorProps {
-  content: string;
-  thumbnail: string;
-  setThumbnail: React.Dispatch<React.SetStateAction<string>>;
-  setContent: React.Dispatch<React.SetStateAction<string>>;
-}
+import useEditStore from '@store/useEditStore';
 
-const Editor = ({ content, setContent, thumbnail, setThumbnail }: EditorProps) => {
+const Editor = () => {
   const editorRef = useRef<DiaryEditor>(null);
+  const {content, setContent, thumbnail, setThumbnail} = useEditStore();
   const onChangeContent = () => {
     setContent(editorRef.current?.getInstance().getHTML());
   };

--- a/frontend/src/components/Edit/Editor.tsx
+++ b/frontend/src/components/Edit/Editor.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { Editor as DiaryEditor } from '@toast-ui/react-editor';
 
 import { uploadImage } from '@api/Edit';
+
 import useEditStore from '@store/useEditStore';
 
 const Editor = () => {

--- a/frontend/src/components/Edit/Editor.tsx
+++ b/frontend/src/components/Edit/Editor.tsx
@@ -1,13 +1,19 @@
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Editor as DiaryEditor } from '@toast-ui/react-editor';
 
 import { uploadImage } from '@api/Edit';
-
 import useEditStore from '@store/useEditStore';
 
 const Editor = () => {
+  const { state } = useLocation();
   const editorRef = useRef<DiaryEditor>(null);
-  const {content, setContent, thumbnail, setThumbnail} = useEditStore();
+  const { setContent, thumbnail, setThumbnail } = useEditStore();
+
+  useEffect(() => {
+    setThumbnail(state?.thumbnail || '');
+  }, [state]);
+
   const onChangeContent = () => {
     setContent(editorRef.current?.getInstance().getHTML());
   };
@@ -32,7 +38,7 @@ const Editor = () => {
           initialEditType="wysiwyg"
           placeholder="일기를 입력하세요!"
           hideModeSwitch={true}
-          initialValue={content}
+          initialValue={state?.content || ' '}
           onChange={onChangeContent}
           hooks={{
             addImageBlobHook: onUploadImage,

--- a/frontend/src/components/Edit/Header.tsx
+++ b/frontend/src/components/Edit/Header.tsx
@@ -3,14 +3,9 @@ import EmojiPicker from 'emoji-picker-react';
 
 import useEditStore from '@store/useEditStore';
 
-interface HeaderProps {
-  status: string;
-  setStatus: React.Dispatch<React.SetStateAction<string>>;
-}
-
-const Header = ({ status, setStatus }: HeaderProps) => {
+const Header = () => {
   const [showEmoji, setShowEmoji] = useState(false);
-  const { title, setTitle, emoji, setEmoji } = useEditStore();
+  const { title, setTitle, emoji, setEmoji, status, setStatus } = useEditStore();
 
   const toggleEmoji = () => setShowEmoji((prev) => !prev);
 
@@ -18,7 +13,7 @@ const Header = ({ status, setStatus }: HeaderProps) => {
 
   const changeEmoji = (e: React.ChangeEvent<HTMLInputElement>) => setEmoji(e.target.value);
 
-  const toggleStatus = () => setStatus((pre) => (pre === '나만 보기' ? '공개 하기' : '나만 보기'));
+  const toggleStatus = () => setStatus(status === '나만 보기' ? '공개 하기' : '나만 보기');
 
   const onClickEmoji = (emojiData: any) => {
     setEmoji(emojiData.emoji);

--- a/frontend/src/components/Edit/Header.tsx
+++ b/frontend/src/components/Edit/Header.tsx
@@ -1,17 +1,16 @@
 import { useState } from 'react';
 import EmojiPicker from 'emoji-picker-react';
 
+import useEditStore from '@store/useEditStore';
+
 interface HeaderProps {
-  title: string;
-  emoji: string;
   status: string;
-  setTitle: React.Dispatch<React.SetStateAction<string>>;
   setStatus: React.Dispatch<React.SetStateAction<string>>;
-  setEmoji: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const Header = ({ emoji, title, status, setTitle, setStatus, setEmoji }: HeaderProps) => {
+const Header = ({ status, setStatus }: HeaderProps) => {
   const [showEmoji, setShowEmoji] = useState(false);
+  const { title, setTitle, emoji, setEmoji } = useEditStore();
 
   const toggleEmoji = () => setShowEmoji((prev) => !prev);
 

--- a/frontend/src/components/Edit/Header.tsx
+++ b/frontend/src/components/Edit/Header.tsx
@@ -1,11 +1,19 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import EmojiPicker from 'emoji-picker-react';
 
 import useEditStore from '@store/useEditStore';
 
 const Header = () => {
+  const { state } = useLocation();
   const [showEmoji, setShowEmoji] = useState(false);
   const { title, setTitle, emoji, setEmoji, status, setStatus } = useEditStore();
+
+  useEffect(() => {
+    setTitle(state?.title || '');
+    setEmoji(state?.emoji || '😁');
+    setStatus(state?.status === 'public' ? '공개 하기' : '나만 보기');
+  }, [state]);
 
   const toggleEmoji = () => setShowEmoji((prev) => !prev);
 

--- a/frontend/src/components/Edit/KeywordBox.tsx
+++ b/frontend/src/components/Edit/KeywordBox.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react';
 
 import Keyword from '@components/Common/Keyword';
+import useEditStore from '@store/useEditStore';
 
 interface KeywordBoxProps {
-  keywordList: string[];
-  setKeywordList: React.Dispatch<React.SetStateAction<string[]>>;
   onSubmit: () => void;
 }
 
-const KeywordBox = ({ keywordList, setKeywordList, onSubmit }: KeywordBoxProps) => {
+const KeywordBox = ({ onSubmit }: KeywordBoxProps) => {
   const [keyword, setKeyword] = useState<string>('');
+  const { keywordList, setKeywordList } = useEditStore();
 
   const changeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(e.target.value);
@@ -18,7 +18,7 @@ const KeywordBox = ({ keywordList, setKeywordList, onSubmit }: KeywordBoxProps) 
   const addKeyword = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Enter') return;
     if (!keywordList.includes(keyword)) {
-      setKeywordList((pre) => [...pre, keyword]);
+      setKeywordList([...keywordList, keyword]);
     }
 
     setKeyword('');

--- a/frontend/src/components/Edit/KeywordBox.tsx
+++ b/frontend/src/components/Edit/KeywordBox.tsx
@@ -1,15 +1,109 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { createDiary, updateDiary } from '@api/Edit';
+import Loading from '@components/Common/Loading';
 import Keyword from '@components/Common/Keyword';
 import useEditStore from '@store/useEditStore';
+import { useToast } from '@hooks/useToast';
+import { PAGE_URL } from '@util/constants';
 
-interface KeywordBoxProps {
-  onSubmit: () => void;
+interface CreateDiaryParams {
+  title: string;
+  content: string;
+  thumbnail?: string;
+  emotion: string;
+  tagNames?: string[];
+  status: string;
 }
 
-const KeywordBox = ({ onSubmit }: KeywordBoxProps) => {
+const KeywordBox = () => {
+  const queryClient = useQueryClient();
+  const openToast = useToast();
+
+  const navigate = useNavigate();
+  const { state } = useLocation();
   const [keyword, setKeyword] = useState<string>('');
-  const { keywordList, setKeywordList } = useEditStore();
+  const { title, content, emoji, status, thumbnail, keywordList, setKeywordList } = useEditStore();
+  
+  useEffect(() => {
+    setKeywordList(state?.tagNames || []);
+  }, [state])
+
+  const params: CreateDiaryParams = {
+    title,
+    content,
+    emotion: emoji,
+    tagNames: keywordList,
+    status: status === '나만 보기' ? 'private' : 'public',
+    thumbnail,
+  };
+
+  const createDiaryMutation = useMutation({
+    mutationFn: (params: CreateDiaryParams) => createDiary(params),
+    onSuccess: () => {
+      navigate(PAGE_URL.MY_DIARY);
+      queryClient.invalidateQueries({
+        queryKey: ['grass', localStorage.getItem('userId')],
+        refetchType: 'all',
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['emotionStat', localStorage.getItem('userId')],
+        refetchType: 'all',
+      });
+      queryClient.removeQueries({
+        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+      });
+      queryClient.removeQueries({
+        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
+      });
+      openToast('일기가 작성되었습니다!');
+    },
+  });
+
+  const updateDiaryMutation = useMutation({
+    mutationFn: (params: CreateDiaryParams) => updateDiary(params, state.diaryId),
+    onSuccess: () => {
+      navigate(`${PAGE_URL.DETAIL}/${state.diaryId}`);
+      queryClient.invalidateQueries({
+        queryKey: ['grass', localStorage.getItem('userId')],
+        refetchType: 'all',
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['emotionStat', localStorage.getItem('userId')],
+        refetchType: 'all',
+      });
+      queryClient.removeQueries({
+        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
+      });
+      queryClient.removeQueries({
+        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
+      });
+      openToast('일기가 수정되었습니다!');
+    },
+  });
+
+  const onSubmit = () => {
+    if (!title || title.trim() === '' || !content || content.trim() === '') {
+      openToast('제목과 본문은 필수 입력사항입니다!');
+      return;
+    }
+
+    if (state) {
+      updateDiaryMutation.mutate(params, state.diaryId);
+    } else {
+      createDiaryMutation.mutate(params);
+    }
+  };
+
+  if (createDiaryMutation.isError || updateDiaryMutation.isError) {
+    return <div>에러!!</div>;
+  }
+
+  if (createDiaryMutation.isPending || updateDiaryMutation.isPending) {
+    return <Loading phrase="일기를 저장하고 있어요." />;
+  }
 
   const changeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(e.target.value);

--- a/frontend/src/pages/Edit.tsx
+++ b/frontend/src/pages/Edit.tsx
@@ -1,141 +1,15 @@
-import { useEffect } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate, useLocation } from 'react-router-dom';
-
-import { createDiary, updateDiary } from '@api/Edit';
-
 import NavBar from '@components/Common/NavBar';
-import Loading from '@components/Common/Loading';
 import Header from '@components/Edit/Header';
 import Editor from '@components/Edit/Editor';
 import KeywordBox from '@components/Edit/KeywordBox';
 
-import { PAGE_URL } from '@util/constants';
-
-import useEditStore from '@store/useEditStore';
-
-import { useToast } from '@hooks/useToast';
-
-interface CreateDiaryParams {
-  title: string;
-  content: string;
-  thumbnail?: string;
-  emotion: string;
-  tagNames?: string[];
-  status: string;
-}
-
 const Edit = () => {
-  const queryClient = useQueryClient();
-  const openToast = useToast();
-
-  const navigate = useNavigate();
-  const { state } = useLocation();
-
-  const {
-    title,
-    setTitle,
-    emoji,
-    setEmoji,
-    thumbnail,
-    setThumbnail,
-    content,
-    setContent,
-    keywordList,
-    setKeywordList,
-    status,
-    setStatus,
-  } = useEditStore();
-
-  useEffect(() => {
-    setTitle(state?.title || '');
-    setEmoji(state?.emoji || '😁');
-    setThumbnail(state?.thumbnail || '');
-    setContent(state?.content || ' ');
-    setKeywordList(state?.tagNames || []);
-    setStatus(state?.status === 'public' ? '공개 하기' : '나만 보기')
-  }, [state]);
-
-  const params: CreateDiaryParams = {
-    title,
-    content,
-    emotion: emoji,
-    tagNames: keywordList,
-    status: status === '나만 보기' ? 'private' : 'public',
-    thumbnail,
-  };
-
-  const createDiaryMutation = useMutation({
-    mutationFn: (params: CreateDiaryParams) => createDiary(params),
-    onSuccess: () => {
-      navigate(PAGE_URL.MY_DIARY);
-      queryClient.invalidateQueries({
-        queryKey: ['grass', localStorage.getItem('userId')],
-        refetchType: 'all',
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['emotionStat', localStorage.getItem('userId')],
-        refetchType: 'all',
-      });
-      queryClient.removeQueries({
-        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
-      });
-      queryClient.removeQueries({
-        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
-      });
-      openToast('일기가 작성되었습니다!');
-    },
-  });
-
-  const updateDiaryMutation = useMutation({
-    mutationFn: (params: CreateDiaryParams) => updateDiary(params, state.diaryId),
-    onSuccess: () => {
-      navigate(`${PAGE_URL.DETAIL}/${state.diaryId}`);
-      queryClient.invalidateQueries({
-        queryKey: ['grass', localStorage.getItem('userId')],
-        refetchType: 'all',
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['emotionStat', localStorage.getItem('userId')],
-        refetchType: 'all',
-      });
-      queryClient.removeQueries({
-        queryKey: ['dayDiaryList', localStorage.getItem('userId')],
-      });
-      queryClient.removeQueries({
-        queryKey: ['myDayDiaryList', localStorage.getItem('userId')],
-      });
-      openToast('일기가 수정되었습니다!');
-    },
-  });
-
-  const onSubmit = () => {
-    if (!title || title.trim() === '' || !content || content.trim() === '') {
-      openToast('제목과 본문은 필수 입력사항입니다!');
-      return;
-    }
-
-    if (state) {
-      updateDiaryMutation.mutate(params, state.diaryId);
-    } else {
-      createDiaryMutation.mutate(params);
-    }
-  };
-
-  if (createDiaryMutation.isError || updateDiaryMutation.isError) {
-    return <div>에러!!</div>;
-  }
-
-  if (createDiaryMutation.isPending || updateDiaryMutation.isPending) {
-    return <Loading phrase="일기를 저장하고 있어요." />;
-  }
-
   return (
     <div className="flex flex-col items-center justify-start">
       <NavBar />
       <Header />
       <Editor />
-      <KeywordBox onSubmit={onSubmit} />
+      <KeywordBox />
     </div>
   );
 };

--- a/frontend/src/pages/Edit.tsx
+++ b/frontend/src/pages/Edit.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -11,6 +11,8 @@ import Editor from '@components/Edit/Editor';
 import KeywordBox from '@components/Edit/KeywordBox';
 
 import { PAGE_URL } from '@util/constants';
+
+import useEditStore from '@store/useEditStore';
 
 import { useToast } from '@hooks/useToast';
 
@@ -29,14 +31,30 @@ const Edit = () => {
 
   const navigate = useNavigate();
   const { state } = useLocation();
-  const [keywordList, setKeywordList] = useState<string[]>(state?.tagNames || []);
-  const [title, setTitle] = useState(state?.title || '');
-  const [emoji, setEmoji] = useState(state?.emotion || '😁');
   const [status, setStatus] = useState(
     state && state.status === 'public' ? '공개 하기' : '나만 보기',
   );
-  const [thumbnail, setThumbnail] = useState(state?.thumbnail || '');
-  const [content, setContent] = useState(state?.content || ' ');
+
+  const {
+    title,
+    setTitle,
+    emoji,
+    setEmoji,
+    thumbnail,
+    setThumbnail,
+    content,
+    setContent,
+    keywordList,
+    setKeywordList,
+  } = useEditStore();
+
+  useEffect(() => {
+    setTitle(state?.title || '');
+    setEmoji(state?.emoji || '😁');
+    setThumbnail(state?.thumbnail || '');
+    setContent(state?.setContent || ' ');
+    setKeywordList(state?.tagNames || []);
+  }, [state]);
 
   const params: CreateDiaryParams = {
     title,
@@ -115,21 +133,9 @@ const Edit = () => {
   return (
     <div className="flex flex-col items-center justify-start">
       <NavBar />
-      <Header
-        title={title}
-        emoji={emoji}
-        setTitle={setTitle}
-        setEmoji={setEmoji}
-        status={status}
-        setStatus={setStatus}
-      />
-      <Editor
-        content={content}
-        setContent={setContent}
-        thumbnail={thumbnail}
-        setThumbnail={setThumbnail}
-      />
-      <KeywordBox keywordList={keywordList} setKeywordList={setKeywordList} onSubmit={onSubmit} />
+      <Header status={status} setStatus={setStatus} />
+      <Editor />
+      <KeywordBox onSubmit={onSubmit} />
     </div>
   );
 };

--- a/frontend/src/pages/Edit.tsx
+++ b/frontend/src/pages/Edit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -31,9 +31,6 @@ const Edit = () => {
 
   const navigate = useNavigate();
   const { state } = useLocation();
-  const [status, setStatus] = useState(
-    state && state.status === 'public' ? '공개 하기' : '나만 보기',
-  );
 
   const {
     title,
@@ -46,14 +43,17 @@ const Edit = () => {
     setContent,
     keywordList,
     setKeywordList,
+    status,
+    setStatus,
   } = useEditStore();
 
   useEffect(() => {
     setTitle(state?.title || '');
     setEmoji(state?.emoji || '😁');
     setThumbnail(state?.thumbnail || '');
-    setContent(state?.setContent || ' ');
+    setContent(state?.content || ' ');
     setKeywordList(state?.tagNames || []);
+    setStatus(state?.status === 'public' ? '공개 하기' : '나만 보기')
   }, [state]);
 
   const params: CreateDiaryParams = {
@@ -133,7 +133,7 @@ const Edit = () => {
   return (
     <div className="flex flex-col items-center justify-start">
       <NavBar />
-      <Header status={status} setStatus={setStatus} />
+      <Header />
       <Editor />
       <KeywordBox onSubmit={onSubmit} />
     </div>

--- a/frontend/src/store/useEditStore.ts
+++ b/frontend/src/store/useEditStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+
+interface editState {
+  title: string;
+  setTitle: (newTitle: string) => void;
+
+  emoji: string;
+  setEmoji: (newEmoji: string) => void;
+
+  thumbnail: string;
+  setThumbnail: (newThumbnail: string) => void;
+
+  content: string;
+  setContent: (newContent: string) => void;
+
+  keywordList: string[];
+  setKeywordList: (newKeywordList: string[]) => void;
+}
+
+const useEditStore = create<editState>((set) => ({
+  title: '',
+  setTitle: (newTitle) => set({ title: newTitle }),
+
+  emoji: '😁',
+  setEmoji: (newEmoji) => set({ emoji: newEmoji }),
+
+  thumbnail: '',
+  setThumbnail: (newThumbnail) => set({ thumbnail: newThumbnail }),
+
+  content: ' ',
+  setContent: (newContent) => set({ content: newContent }),
+
+  keywordList: [],
+  setKeywordList: (newKeywordList) => set({ keywordList: newKeywordList }),
+}));
+
+export default useEditStore;

--- a/frontend/src/store/useEditStore.ts
+++ b/frontend/src/store/useEditStore.ts
@@ -15,6 +15,9 @@ interface editState {
 
   keywordList: string[];
   setKeywordList: (newKeywordList: string[]) => void;
+
+  status: '공개 하기' | '나만 보기';
+  setStatus: (newStatus: '공개 하기' | '나만 보기') => void;
 }
 
 const useEditStore = create<editState>((set) => ({
@@ -32,6 +35,9 @@ const useEditStore = create<editState>((set) => ({
 
   keywordList: [],
   setKeywordList: (newKeywordList) => set({ keywordList: newKeywordList }),
+
+  status: '나만 보기',
+  setStatus: (newStatus) => set({ status: newStatus }),
 }));
 
 export default useEditStore;

--- a/frontend/src/store/useViewTypeStore.ts
+++ b/frontend/src/store/useViewTypeStore.ts
@@ -4,7 +4,7 @@ import { viewTypes } from '@type/pages/MyDiary';
 
 interface viewTypeState {
   viewType: viewTypes;
-  setViewType:(newViewType: viewTypes) => void;
+  setViewType: (newViewType: viewTypes) => void;
 }
 
 const useViewTypeStore = create<viewTypeState>((set) => ({

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,5 +1,5 @@
-const SERVER_URL = 'https://dandi-ary.site/api';
-// const SERVER_URL = 'http://localhost:3000';
+// const SERVER_URL = 'https://dandi-ary.site/api';
+const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';
 const USER = '/users';

--- a/frontend/src/util/apiPath.ts
+++ b/frontend/src/util/apiPath.ts
@@ -1,5 +1,5 @@
-// const SERVER_URL = 'https://dandi-ary.site/api';
-const SERVER_URL = 'http://localhost:3000';
+const SERVER_URL = 'https://dandi-ary.site/api';
+// const SERVER_URL = 'http://localhost:3000';
 
 const AUTH = '/auth';
 const USER = '/users';


### PR DESCRIPTION
## 이슈 번호
#363

## 완료한 기능 명세
- Edit 페이지의 상태들을 useEditStore로 분리
## 특이 사항
- Editor 컴포넌트의 DiaryEditor의 initialValue가 새로 받아온 content로 바뀌지 않는 문제
- 임시방편으로 useLocation의 state의 값을 바로 받아 오는 것으로 변경
