### PR TITLE
[FE] Edit 페이지 state 전달 방식 수정

### DIFF
--- a/frontend/src/components/Edit/Editor.tsx
+++ b/frontend/src/components/Edit/Editor.tsx
@@ -1,5 +1,4 @@
-import { useRef, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useRef } from 'react';
 import { Editor as DiaryEditor } from '@toast-ui/react-editor';
 
 import { uploadImage } from '@api/Edit';
@@ -7,13 +6,8 @@ import { uploadImage } from '@api/Edit';
 import useEditStore from '@store/useEditStore';
 
 const Editor = () => {
-  const { state } = useLocation();
   const editorRef = useRef<DiaryEditor>(null);
-  const { setContent, thumbnail, setThumbnail } = useEditStore();
-
-  useEffect(() => {
-    setThumbnail(state?.thumbnail || '');
-  }, [state]);
+  const { content, setContent, thumbnail, setThumbnail } = useEditStore();
 
   const onChangeContent = () => {
     setContent(editorRef.current?.getInstance().getHTML());
@@ -39,7 +33,7 @@ const Editor = () => {
           initialEditType="wysiwyg"
           placeholder="일기를 입력하세요!"
           hideModeSwitch={true}
-          initialValue={state?.content || ' '}
+          initialValue={content}
           onChange={onChangeContent}
           hooks={{
             addImageBlobHook: onUploadImage,

--- a/frontend/src/components/Edit/Header.tsx
+++ b/frontend/src/components/Edit/Header.tsx
@@ -1,19 +1,11 @@
-import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useState } from 'react';
 import EmojiPicker from 'emoji-picker-react';
 
 import useEditStore from '@store/useEditStore';
 
 const Header = () => {
-  const { state } = useLocation();
   const [showEmoji, setShowEmoji] = useState(false);
   const { title, setTitle, emoji, setEmoji, status, setStatus } = useEditStore();
-
-  useEffect(() => {
-    setTitle(state?.title || '');
-    setEmoji(state?.emoji || '😁');
-    setStatus(state?.status === 'public' ? '공개 하기' : '나만 보기');
-  }, [state]);
 
   const toggleEmoji = () => setShowEmoji((prev) => !prev);
 

--- a/frontend/src/components/Edit/KeywordBox.tsx
+++ b/frontend/src/components/Edit/KeywordBox.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -25,11 +25,8 @@ const KeywordBox = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const [keyword, setKeyword] = useState<string>('');
-  const { title, content, emoji, status, thumbnail, keywordList, setKeywordList } = useEditStore();
-  
-  useEffect(() => {
-    setKeywordList(state?.tagNames || []);
-  }, [state])
+  const { diaryId, title, content, emoji, status, thumbnail, keywordList, setKeywordList } =
+    useEditStore();
 
   const params: CreateDiaryParams = {
     title,
@@ -63,9 +60,9 @@ const KeywordBox = () => {
   });
 
   const updateDiaryMutation = useMutation({
-    mutationFn: (params: CreateDiaryParams) => updateDiary(params, state.diaryId),
+    mutationFn: (params: CreateDiaryParams) => updateDiary(params, diaryId),
     onSuccess: () => {
-      navigate(`${PAGE_URL.DETAIL}/${state.diaryId}`);
+      navigate(`${PAGE_URL.DETAIL}/${diaryId}`);
       queryClient.invalidateQueries({
         queryKey: ['grass', localStorage.getItem('userId')],
         refetchType: 'all',
@@ -90,8 +87,8 @@ const KeywordBox = () => {
       return;
     }
 
-    if (state) {
-      updateDiaryMutation.mutate(params, state.diaryId);
+    if (state?.type == 'update') {
+      updateDiaryMutation.mutate(params);
     } else {
       createDiaryMutation.mutate(params);
     }

--- a/frontend/src/pages/Detail.tsx
+++ b/frontend/src/pages/Detail.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -10,20 +11,24 @@ import DiaryContent from '@components/Detail/DiaryContent';
 import Alert from '@components/Common/Alert';
 import Loading from '@components/Common/Loading';
 
-import { PAGE_URL } from '@util/constants';
+import useEditStore from '@store/useEditStore';
 
 import { useToast } from '@hooks/useToast';
 import useModal from '@hooks/useModal';
+
+import { PAGE_URL } from '@util/constants';
 
 const Detail = () => {
   const queryClient = useQueryClient();
   const openToast = useToast();
   const navigate = useNavigate();
-
+  const { setDiaryId, setTitle, setEmoji, setThumbnail, setContent, setKeywordList, setStatus } =
+    useEditStore();
   const { openModal, closeModal } = useModal();
 
   const params = useParams();
   const diaryId = Number(params.diaryId);
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ['diary', diaryId],
     queryFn: () => referDiary(diaryId),
@@ -71,6 +76,18 @@ const Detail = () => {
     });
   };
 
+  useEffect(() => {
+    if (data) {
+      setDiaryId(diaryId);
+      setTitle(data.title);
+      setContent(data.content);
+      setEmoji(data.emotion);
+      setThumbnail(data.thumbnail);
+      setKeywordList(data.tagNames);
+      setStatus(data.status === 'public' ? '공개 하기' : '나만 보기');
+    }
+  }, [data]);
+
   if (isLoading) {
     return <Loading phrase="로딩 중이에요." />;
   }
@@ -96,13 +113,7 @@ const Detail = () => {
                 onClick={() =>
                   navigate(PAGE_URL.EDIT, {
                     state: {
-                      diaryId: diaryId,
-                      title: data.title,
-                      content: data.content,
-                      emotion: data.emotion,
-                      thumbnail: data.thumbnail,
-                      tagNames: data.tagNames,
-                      status: data.status,
+                      type: 'update',
                     },
                   })
                 }

--- a/frontend/src/pages/Edit.tsx
+++ b/frontend/src/pages/Edit.tsx
@@ -1,9 +1,30 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import NavBar from '@components/Common/NavBar';
 import Header from '@components/Edit/Header';
 import Editor from '@components/Edit/Editor';
 import KeywordBox from '@components/Edit/KeywordBox';
 
+import useEditStore from '@store/useEditStore';
+
 const Edit = () => {
+  const { state } = useLocation();
+  const { setDiaryId, setTitle, setEmoji, setThumbnail, setContent, setKeywordList, setStatus } =
+    useEditStore();
+
+  useEffect(() => {
+    if (state?.type !== 'update') {
+      setDiaryId(0);
+      setTitle('');
+      setContent(' ');
+      setEmoji('😁');
+      setThumbnail('');
+      setKeywordList([]);
+      setStatus('나만 보기');
+    }
+  }, []);
+
   return (
     <div className="flex flex-col items-center justify-start">
       <NavBar />

--- a/frontend/src/store/useEditStore.ts
+++ b/frontend/src/store/useEditStore.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand';
 
 interface editState {
+  diaryId: number;
+  setDiaryId: (newDiaryId: number) => void;
+
   title: string;
   setTitle: (newTitle: string) => void;
 
@@ -21,6 +24,9 @@ interface editState {
 }
 
 const useEditStore = create<editState>((set) => ({
+  diaryId: 0,
+  setDiaryId: (newDiaryId) => set({diaryId: newDiaryId}),
+
   title: '',
   setTitle: (newTitle) => set({ title: newTitle }),
 


### PR DESCRIPTION
## 이슈 번호
#363

## 완료한 기능 명세
- 기존 useNavigate의 state로 정보를 전달하던 방식에서 store에 정보를 저장하여 전달하는 방식으로 변경
- 이전에 문제였던 DiaryEditor의 initialValue가 새로 받아온 content로 바뀌지 않는 문제 해결
## 특이 사항
- 이전 방식이 state의 존재 여부로 update인지 create인지 구별하기 때문에 state에 update 요청인지 확인할 수 있도록 type을 전달
