### PR TITLE
[BE] Reactions e2e 테스트

### DIFF
--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -48,6 +48,7 @@ describe('FriendsController (e2e)', () => {
   let user: User;
   let accessToken: string;
   let diary: Diary;
+  let url: string;
 
   const userInfo = {
     socialId: '1234',
@@ -81,6 +82,7 @@ describe('FriendsController (e2e)', () => {
     accessToken = await testLogin(user);
     diaryInfo['author'] = user;
     diary = await diariesRepository.save(diaryInfo);
+    url = `/reactions/${diary.id}`;
   });
 
   afterEach(async () => {
@@ -90,7 +92,6 @@ describe('FriendsController (e2e)', () => {
   describe('/reactions/:diaryId (GET)', () => {
     it('특정 일기의 리액션 조회', async () => {
       // given
-      const url = `/reactions/${diary.id}`;
       const friend = await usersRepository.save(friendInfo);
 
       await reactionsRepository.save({ user, diary, reaction: '🔥' });
@@ -108,9 +109,6 @@ describe('FriendsController (e2e)', () => {
     });
 
     it('일기의 리액션 없는 경우 빈 배열 반환', async () => {
-      // given
-      const url = `/reactions/${diary.id}`;
-
       // when
       const response = await request(app.getHttpServer())
         .get(url)
@@ -128,9 +126,6 @@ describe('FriendsController (e2e)', () => {
     });
 
     it('리액션 저장', async () => {
-      // given
-      const url = `/reactions/${diary.id}`;
-
       // when
       const response = await request(app.getHttpServer())
         .post(url)
@@ -144,8 +139,6 @@ describe('FriendsController (e2e)', () => {
 
     it('해당 일기에 이미 리액션을 남긴 경우 예외 발생', async () => {
       // given
-      const url = `/reactions/${diary.id}`;
-
       await reactionsRepository.save({ user, diary, reaction: '🔥' });
       jest.clearAllMocks();
 
@@ -158,6 +151,43 @@ describe('FriendsController (e2e)', () => {
       // then
       expect(response.statusCode).toEqual(400);
       expect(response.body.message).toEqual('이미 해당 글에 리액션을 남겼습니다.');
+      expect(reactionsRepository.save).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('/reactions/:diaryId (PUT)', () => {
+    beforeEach(() => {
+      jest.spyOn(reactionsRepository, 'save');
+    });
+
+    it('리액션 수정', async () => {
+      // given
+      await reactionsRepository.save({ user, diary, reaction: '🔥' });
+
+      // when
+      const response = await request(app.getHttpServer())
+        .put(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🥰' });
+
+      // then
+      expect(response.statusCode).toEqual(200);
+      expect(reactionsRepository.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('리액션이 존재하지 않는데 해당 요청을 보낸 경우 예외 발생', async () => {
+      // given
+      jest.clearAllMocks();
+
+      // when
+      const response = await request(app.getHttpServer())
+        .put(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🥰' });
+
+      // then
+      expect(response.statusCode).toEqual(400);
+      expect(response.body.message).toEqual('리액션 기록이 존재하지 않습니다.');
       expect(reactionsRepository.save).toHaveBeenCalledTimes(0);
     });
   });

--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -121,4 +121,44 @@ describe('FriendsController (e2e)', () => {
       expect(response.body.reactionList).toEqual([]);
     });
   });
+
+  describe('/reactions/:diaryId (POST)', () => {
+    beforeEach(() => {
+      jest.spyOn(reactionsRepository, 'save');
+    });
+
+    it('리액션 저장', async () => {
+      // given
+      const url = `/reactions/${diary.id}`;
+
+      // when
+      const response = await request(app.getHttpServer())
+        .post(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🥰' });
+
+      // then
+      expect(response.statusCode).toEqual(201);
+      expect(reactionsRepository.save).toHaveBeenCalled();
+    });
+
+    it('해당 일기에 이미 리액션을 남긴 경우 예외 발생', async () => {
+      // given
+      const url = `/reactions/${diary.id}`;
+
+      await reactionsRepository.save({ user, diary, reaction: '🔥' });
+      jest.clearAllMocks();
+
+      // when
+      const response = await request(app.getHttpServer())
+        .post(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🥰' });
+
+      // then
+      expect(response.statusCode).toEqual(400);
+      expect(response.body.message).toEqual('이미 해당 글에 리액션을 남겼습니다.');
+      expect(reactionsRepository.save).toHaveBeenCalledTimes(0);
+    });
+  });
 });

--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -1,0 +1,46 @@
+import * as request from 'supertest';
+import { ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { DataSource, QueryRunner } from 'typeorm';
+import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
+
+describe('FriendsController (e2e)', () => {
+  let app: INestApplication;
+  let queryRunner: QueryRunner;
+
+  const mockUser = { id: 1 };
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = mockUser;
+
+          return true;
+        },
+      })
+      .compile();
+
+    const dataSource = module.get<DataSource>(DataSource);
+    queryRunner = dataSource.createQueryRunner();
+    dataSource.createQueryRunner = jest.fn();
+    queryRunner.release = jest.fn();
+    (dataSource.createQueryRunner as jest.Mock).mockReturnValue(queryRunner);
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    await queryRunner.startTransaction();
+  });
+
+  afterEach(async () => {
+    await queryRunner.rollbackTransaction();
+  });
+});

--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -87,24 +87,38 @@ describe('FriendsController (e2e)', () => {
     await queryRunner.rollbackTransaction();
   });
 
-  // describe('/reactions/:diaryId (GET)', () => {
-  //   it('특정 일기의 리액션 조회', async () => {
-  //     // given
-  //     const url = `/reactions/${diary.id}`;
-  //     const friend = await usersRepository.save(friendInfo);
+  describe('/reactions/:diaryId (GET)', () => {
+    it('특정 일기의 리액션 조회', async () => {
+      // given
+      const url = `/reactions/${diary.id}`;
+      const friend = await usersRepository.save(friendInfo);
 
-  //     await reactionsRepository.save({ user, diary, reaction: '🔥' });
-  //     await reactionsRepository.save({ user: friend, diary, reaction: '🥰' });
+      await reactionsRepository.save({ user, diary, reaction: '🔥' });
+      await reactionsRepository.save({ user: friend, diary, reaction: '🥰' });
 
-  //     // when
-  //     const response = await request(app.getHttpServer())
-  //       .get(url)
-  //       .set('Cookie', [`utk=${accessToken}`]);
+      // when
+      const response = await request(app.getHttpServer())
+        .get(url)
+        .set('Cookie', [`utk=${accessToken}`]);
 
-  //     // then
-  //     expect(response.statusCode).toEqual(200);
-  //     expect(response.body.reactionList).toHaveLength(2);
-  //     expect(response.body.reactionList[0].reaction).toEqual('🔥');
-  //   });
-  // });
+      // then
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.reactionList).toHaveLength(2);
+      expect(response.body.reactionList[0].reaction).toEqual('🔥');
+    });
+
+    it('일기의 리액션 없는 경우 빈 배열 반환', async () => {
+      // given
+      const url = `/reactions/${diary.id}`;
+
+      // when
+      const response = await request(app.getHttpServer())
+        .get(url)
+        .set('Cookie', [`utk=${accessToken}`]);
+
+      // then
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.reactionList).toEqual([]);
+    });
+  });
 });

--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -14,7 +14,7 @@ import * as cookieParser from 'cookie-parser';
 import { User } from 'src/users/entity/user.entity';
 import { testLogin } from 'test/utils/testLogin';
 
-describe('FriendsController (e2e)', () => {
+describe('ReactionsController (e2e)', () => {
   let app: INestApplication;
   let queryRunner: QueryRunner;
   let reactionsRepository: ReactionsRepository;
@@ -60,13 +60,6 @@ describe('FriendsController (e2e)', () => {
     email: 'test@abc.com',
     profileImage: 'profile image',
   };
-  const friendInfo = {
-    socialId: '12345',
-    socialType: SocialType.NAVER,
-    nickname: 'friend',
-    email: 'friend@abc.com',
-    profileImage: 'profile image',
-  };
   const diaryInfo = {
     title: '제목',
     content: '<p>내용</p>',
@@ -95,6 +88,13 @@ describe('FriendsController (e2e)', () => {
   describe('/reactions/:diaryId (GET)', () => {
     it('특정 일기의 리액션 조회', async () => {
       // given
+      const friendInfo = {
+        socialId: '12345',
+        socialType: SocialType.NAVER,
+        nickname: 'friend',
+        email: 'friend@abc.com',
+        profileImage: 'profile image',
+      };
       const friend = await usersRepository.save(friendInfo);
 
       await reactionsRepository.save({ user, diary, reaction: '🔥' });

--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -39,6 +39,9 @@ describe('FriendsController (e2e)', () => {
     app = module.createNestApplication();
     app.use(cookieParser());
     await app.init();
+
+    jest.spyOn(reactionsRepository, 'save');
+    jest.spyOn(reactionsRepository, 'remove');
   });
 
   afterAll(async () => {
@@ -121,10 +124,6 @@ describe('FriendsController (e2e)', () => {
   });
 
   describe('/reactions/:diaryId (POST)', () => {
-    beforeEach(() => {
-      jest.spyOn(reactionsRepository, 'save');
-    });
-
     it('리액션 저장', async () => {
       // when
       const response = await request(app.getHttpServer())
@@ -157,7 +156,7 @@ describe('FriendsController (e2e)', () => {
 
   describe('/reactions/:diaryId (PUT)', () => {
     beforeEach(() => {
-      jest.spyOn(reactionsRepository, 'save');
+      jest.clearAllMocks();
     });
 
     it('리액션 수정', async () => {
@@ -176,9 +175,6 @@ describe('FriendsController (e2e)', () => {
     });
 
     it('리액션이 존재하지 않는데 해당 요청을 보낸 경우 예외 발생', async () => {
-      // given
-      jest.clearAllMocks();
-
       // when
       const response = await request(app.getHttpServer())
         .put(url)
@@ -189,6 +185,56 @@ describe('FriendsController (e2e)', () => {
       expect(response.statusCode).toEqual(400);
       expect(response.body.message).toEqual('리액션 기록이 존재하지 않습니다.');
       expect(reactionsRepository.save).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('/reactions/:diaryId (DELETE)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('리액션 삭제', async () => {
+      // given
+      await reactionsRepository.save({ user, diary, reaction: '🔥' });
+
+      // when
+      const response = await request(app.getHttpServer())
+        .delete(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🔥' });
+
+      // then
+      expect(response.statusCode).toEqual(200);
+      expect(reactionsRepository.remove).toHaveBeenCalled();
+    });
+
+    it('삭제하려는 리액션이 존재하지 않는 경우 예외 발생', async () => {
+      // when
+      const response = await request(app.getHttpServer())
+        .delete(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🔥' });
+
+      // then
+      expect(response.statusCode).toEqual(400);
+      expect(response.body.message).toEqual('이미 삭제된 리액션 정보입니다.');
+      expect(reactionsRepository.remove).toHaveBeenCalledTimes(0);
+    });
+
+    it('기존에 남긴 리액션과 삭제하려는 리액션이 일치하지 않는 경우 예외 발생', async () => {
+      // given
+      await reactionsRepository.save({ user, diary, reaction: '🔥' });
+
+      // when
+      const response = await request(app.getHttpServer())
+        .delete(url)
+        .set('Cookie', [`utk=${accessToken}`])
+        .send({ reaction: '🥰' });
+
+      // then
+      expect(response.statusCode).toEqual(400);
+      expect(response.body.message).toEqual('이미 삭제된 리액션 정보입니다.');
+      expect(reactionsRepository.remove).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/backend/test/reactions/reactions.e2e-spec.ts
+++ b/backend/test/reactions/reactions.e2e-spec.ts
@@ -1,30 +1,34 @@
 import * as request from 'supertest';
-import { ExecutionContext, INestApplication } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
 import { DataSource, QueryRunner } from 'typeorm';
-import { JwtAuthGuard } from 'src/auth/guards/jwtAuth.guard';
+import { Diary } from 'src/diaries/entity/diary.entity';
+import { SocialType } from 'src/users/entity/socialType';
+import { DiaryStatus } from 'src/diaries/entity/diaryStatus';
+import { DiariesRepository } from 'src/diaries/diaries.repository';
+import { ReactionsRepository } from 'src/reactions/reactions.repository';
+import { UsersRepository } from 'src/users/users.repository';
+import { MoodDegree } from 'src/diaries/utils/diaries.constant';
+import * as cookieParser from 'cookie-parser';
+import { User } from 'src/users/entity/user.entity';
+import { testLogin } from 'test/utils/testLogin';
 
 describe('FriendsController (e2e)', () => {
   let app: INestApplication;
   let queryRunner: QueryRunner;
-
-  const mockUser = { id: 1 };
+  let reactionsRepository: ReactionsRepository;
+  let diariesRepository: DiariesRepository;
+  let usersRepository: UsersRepository;
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
       imports: [AppModule],
-    })
-      .overrideGuard(JwtAuthGuard)
-      .useValue({
-        canActivate: (context: ExecutionContext) => {
-          const req = context.switchToHttp().getRequest();
-          req.user = mockUser;
+    }).compile();
 
-          return true;
-        },
-      })
-      .compile();
+    reactionsRepository = module.get<ReactionsRepository>(ReactionsRepository);
+    diariesRepository = module.get<DiariesRepository>(DiariesRepository);
+    usersRepository = module.get<UsersRepository>(UsersRepository);
 
     const dataSource = module.get<DataSource>(DataSource);
     queryRunner = dataSource.createQueryRunner();
@@ -33,14 +37,74 @@ describe('FriendsController (e2e)', () => {
     (dataSource.createQueryRunner as jest.Mock).mockReturnValue(queryRunner);
 
     app = module.createNestApplication();
+    app.use(cookieParser());
     await app.init();
   });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  let user: User;
+  let accessToken: string;
+  let diary: Diary;
+
+  const userInfo = {
+    socialId: '1234',
+    socialType: SocialType.NAVER,
+    nickname: 'test',
+    email: 'test@abc.com',
+    profileImage: 'profile image',
+  };
+  const friendInfo = {
+    socialId: '12345',
+    socialType: SocialType.NAVER,
+    nickname: 'friend',
+    email: 'friend@abc.com',
+    profileImage: 'profile image',
+  };
+  const diaryInfo = {
+    title: '제목',
+    content: '<p>내용</p>',
+    thumbnail: null,
+    emotion: '🥰',
+    tagNames: ['일기', '안녕'],
+    status: DiaryStatus.PUBLIC,
+    summary: '일기 요약',
+    mood: MoodDegree.SO_SO,
+  };
+
   beforeEach(async () => {
     await queryRunner.startTransaction();
+
+    user = await usersRepository.save(userInfo);
+    accessToken = await testLogin(user);
+    diaryInfo['author'] = user;
+    diary = await diariesRepository.save(diaryInfo);
   });
 
   afterEach(async () => {
     await queryRunner.rollbackTransaction();
   });
+
+  // describe('/reactions/:diaryId (GET)', () => {
+  //   it('특정 일기의 리액션 조회', async () => {
+  //     // given
+  //     const url = `/reactions/${diary.id}`;
+  //     const friend = await usersRepository.save(friendInfo);
+
+  //     await reactionsRepository.save({ user, diary, reaction: '🔥' });
+  //     await reactionsRepository.save({ user: friend, diary, reaction: '🥰' });
+
+  //     // when
+  //     const response = await request(app.getHttpServer())
+  //       .get(url)
+  //       .set('Cookie', [`utk=${accessToken}`]);
+
+  //     // then
+  //     expect(response.statusCode).toEqual(200);
+  //     expect(response.body.reactionList).toHaveLength(2);
+  //     expect(response.body.reactionList[0].reaction).toEqual('🔥');
+  //   });
+  // });
 });


### PR DESCRIPTION
## 이슈 번호

#382 

## 완료한 기능 명세

- [X] Reactions e2e 테스트 작성
![image](https://github.com/boostcampwm2023/web18_Dandi/assets/113580033/e2a2452a-6925-4c06-a9b5-eda40c1c5342)

`jwtAuthGuard`를 mocking하는게 더 복잡한 것 같아서 그냥 모든 테스트 데이터를 실제로 생성해서 쓰도록 했습니닷
마지막 e2e입니다 🔥🔥
