### PR TITLE
[FE] 로컬 스토리지 초기화 오류 해결

### DIFF
--- a/frontend/src/api/fetchInterceptor.ts
+++ b/frontend/src/api/fetchInterceptor.ts
@@ -10,6 +10,7 @@ const interceptor = async (url: string, option: any) => {
   const refreshResponse = await refresh();
 
   if (refreshResponse?.status === 401 || refreshResponse?.status === 500) {
+    localStorage.clear();
     window.location.href = PAGE_URL.LOGIN;
     return refreshResponse;
   }

--- a/frontend/src/pages/OAuthLogin.tsx
+++ b/frontend/src/pages/OAuthLogin.tsx
@@ -8,6 +8,7 @@ import useUserStore from '@store/useUserStore';
 const AuthLogin = () => {
   const navigate = useNavigate();
   const { setUserId } = useUserStore();
+  
   useEffect(() => {
     const getUserId = async () => {
       const code = new URL(window.location.href).searchParams.get('code') ?? '';


### PR DESCRIPTION
## 이슈 번호
#392

## 완료한 기능 명세
- fetch 도중 401 또는 500 에러가 발생했을 때, localStorage를 clear 해주어 이전 user 정보를 초기화 하여 문제 해결
